### PR TITLE
FeatureMap - TransitionGroup Linking

### DIFF
--- a/massseer/structs/FeatureMap.py
+++ b/massseer/structs/FeatureMap.py
@@ -1,0 +1,140 @@
+from massseer.structs.Chromatogram import Chromatogram
+from massseer.structs.Mobilogram import Mobilogram
+from massseer.structs.Spectrum import Spectrum
+from typing import List
+import pandas as pd
+import numpy as np
+
+class FeatureMap:
+    '''
+    Class for storing a feature map
+    '''
+    def __init__(self, feature_df: pd.DataFrame):
+        self.feature_df = feature_df
+        self.has_im = 'im' in feature_df.columns
+
+    @staticmethod
+    def average_intensity_across_two_dimensions(df: pd.DataFrame, index: str='im', columns: str='rt', values: str='int', axis: int=0):
+        """
+        Compute the average intensity across two dimensions of a DataFrame.
+
+        Args:
+            df (pd.DataFrame): The input DataFrame.
+            index (str): The name of the index column. Default is 'im'.
+            columns (str): The name of the columns. Default is 'rt'.
+            values (str): The name of the values. Default is 'int'.
+            axis (int): The axis to compute the average intensity across. Must be 0 or 1. Default is 0.
+
+        Returns:
+            Tuple of two numpy arrays: The x-axis values and the average intensity values.
+        """
+        matrix = df.pivot_table(index=index, columns=columns, values=values)
+
+        if axis == 0:
+            x_arr = matrix.columns.to_numpy()
+        elif axis == 1:
+            x_arr = matrix.index.to_numpy()
+        else:
+            raise ValueError(f'axis must be 0 or 1, not {axis}')
+
+        matrix = matrix.to_numpy()
+        int_arr = np.mean(matrix, axis=axis)
+
+        return x_arr, int_arr
+
+
+    def get_precursor_chromatograms(self) -> List[Chromatogram]:
+        '''
+        Get a list of precursor chromatograms from the feature map
+        '''
+        # Filter the feature map to only precursor chromatograms
+        precursor_df = self.feature_df[self.feature_df['ms_level']==1]
+        # If ion mobility data is present, compute mean of intensities across ion mobility for retention time
+        if 'im' in precursor_df.columns:
+            rt_arr, int_arr = FeatureMap.average_intensity_across_two_dimensions(precursor_df)
+        else:
+            rt_arr = precursor_df['rt'].to_numpy()
+            int_arr = precursor_df['int'].to_numpy()
+        precursor_chromatogram = Chromatogram(rt_arr, int_arr, f'Precursor - {pd.unique(precursor_df["precursor_mz"])}')
+        return [precursor_chromatogram]
+
+    def get_transition_chromatograms(self) -> List[Chromatogram]:
+        '''
+        Get a list of transition chromatograms from the feature map
+        '''
+        # Filter the feature map to only transition chromatograms
+        transition_df = self.feature_df[self.feature_df['ms_level']==2]
+        transition_chromatograms = []
+        for transition in pd.unique(transition_df['product_mz']):
+            transition_df_tmp = transition_df[transition_df['product_mz']==transition]
+
+            # If ion mobility data is present, compute mean of intensities across ion mobility for retention time
+            if 'im' in transition_df_tmp.columns and transition_df_tmp.shape[0] > 1:
+                rt_arr, int_arr = FeatureMap.average_intensity_across_two_dimensions(transition_df_tmp)
+            else:
+                rt_arr = transition_df_tmp['rt'].to_numpy()
+                int_arr = transition_df_tmp['int'].to_numpy()
+            transition_chromatogram = Chromatogram(rt_arr, int_arr, f'{transition}')
+            transition_chromatograms.append(transition_chromatogram)
+        return transition_chromatograms
+
+    def get_precursor_mobilograms(self) -> List[Mobilogram]:
+        '''
+        Get a list of precursor ion mobility from the feature map
+        '''
+        # Filter the feature map to only precursor ion mobility
+        precursor_df = self.feature_df[self.feature_df['ms_level']==1]
+        # If ion mobility data is present, compute mean of intensities across retention time for ion mobility
+        if 'rt' in precursor_df.columns:
+            im_arr, int_arr = FeatureMap.average_intensity_across_two_dimensions(precursor_df, axis=1)
+        else:
+            im_arr = precursor_df['im'].to_numpy()
+            int_arr = precursor_df['int'].to_numpy()
+        precursor_ion_mobility = Mobilogram(im_arr, int_arr, f'Precursor - {pd.unique(precursor_df["precursor_mz"])}')
+        return [precursor_ion_mobility]
+
+    def get_transition_mobilograms(self) -> List[Mobilogram]:
+        '''
+        Get a list of transition ion mobility from the feature map
+        '''
+        # Filter the feature map to only transition ion mobility
+        transition_df = self.feature_df[self.feature_df['ms_level']==2]
+        transition_ion_mobilities = []
+        for transition in pd.unique(transition_df['product_mz']):
+            transition_df_tmp = transition_df[transition_df['product_mz']==transition]
+
+            # If ion mobility data is present, compute mean of intensities across retention time for ion mobility
+            if 'im' in transition_df_tmp.columns  and transition_df_tmp.shape[0] > 1:
+                im_arr, int_arr = FeatureMap.average_intensity_across_two_dimensions(transition_df_tmp, axis=1)
+            else:
+                im_arr = transition_df_tmp['im'].to_numpy()
+                int_arr = transition_df_tmp['int'].to_numpy()
+            transition_ion_mobility = Mobilogram(im_arr, int_arr, f'{transition}')
+            transition_ion_mobilities.append(transition_ion_mobility)
+        return transition_ion_mobilities
+
+    def get_precursor_spectra(self) -> List[Spectrum]:
+        '''
+        Get a list of precursor spectra from the feature map
+        '''
+        # Filter the feature map to only precursor spectra
+        precursor_df = self.feature_df[self.feature_df['ms_level']==1]
+        precursor_spectra = []
+        for precursor in pd.unique(precursor_df['precursor_mz']):
+            precursor_df = precursor_df[precursor_df['precursor_mz']==precursor]
+            precursor_spectrum = Spectrum(precursor_df['mz'].to_numpy(), precursor_df['int'].to_numpy(), f'Precursor - {precursor}')
+            precursor_spectra.append(precursor_spectrum)
+        return precursor_spectra
+
+    def get_transition_spectra(self) -> List[Spectrum]:
+        '''
+        Get a list of transition spectra from the feature map
+        '''
+        # Filter the feature map to only transition spectra
+        transition_df = self.feature_df[self.feature_df['ms_level']==2]
+        transition_spectra = []
+        for transition in pd.unique(transition_df['product_mz']):
+            transition_df_tmp = transition_df[transition_df['product_mz']==transition]
+            transition_spectrum = Spectrum(transition_df_tmp['mz'].to_numpy(), transition_df_tmp['int'].to_numpy(), f'{transition}')
+            transition_spectra.append(transition_spectrum)
+        return transition_spectra

--- a/massseer/structs/Mobilogram.py
+++ b/massseer/structs/Mobilogram.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+class Mobilogram:
+    ''' 
+    This is a single mobilogram object. Holds the data and metadata of a mobilogram
+    '''
+    def __init__(self, im, intensity, label):
+        self.intensity = np.array(intensity)
+        self.im = np.array(im)
+        self.label = label
+
+    def __str__(self):
+        return f"{'-'*8} Mobilogram {'-'*8}\nlabel: {self.label}\nlength of mobilogram: {len(self.im)}"

--- a/massseer/structs/Spectrum.py
+++ b/massseer/structs/Spectrum.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+class Spectrum:
+    ''' 
+    This is a single spectrum object. Holds the data and metadata of a spectrum
+    '''
+    def __init__(self, mz, intensity, label):
+        self.intensity = np.array(intensity)
+        self.mz = np.array(mz)
+        self.label = label
+
+    def __str__(self):
+        return f"{'-'*8} Spectrum {'-'*8}\nlabel: {self.label}\nlength of spectrum: {len(self.mz)}"

--- a/massseer/structs/TransitionGroup.py
+++ b/massseer/structs/TransitionGroup.py
@@ -1,10 +1,68 @@
 from massseer.structs.Chromatogram import Chromatogram
-from typing import List
+from massseer.structs.Mobilogram import Mobilogram
+from massseer.structs.Spectrum import Spectrum
+from massseer.structs.FeatureMap import FeatureMap
+from typing import List, Optional
+import pandas as pd
 
 class TransitionGroup:
     '''
     Class for Storing a transition group
     '''
-    def __init__(self, precursorChroms: List[Chromatogram], transitionChroms: List[Chromatogram]):
+    def __init__(self, precursorChroms: List[Chromatogram], transitionChroms: List[Chromatogram], precursorMobilos: Optional[List[Mobilogram]], transitionMobilos: Optional[List[Mobilogram]], precursorSpectra: Optional[List[Spectrum]], transitionSpectra: Optional[List[Spectrum]]):
         self.precursorChroms = precursorChroms
         self.transitionChroms = transitionChroms
+        self.precursorMobilos = precursorMobilos
+        self.transitionMobilos = transitionMobilos
+        self.precursorSpectra = precursorSpectra
+        self.transitionSpectra = transitionSpectra
+        self._protein = None
+
+    def __str__(self) -> str:
+        '''
+        Returns a string representation of the transition group.
+
+        Returns:
+            str: A string representation of the transition group.
+        '''
+        return f"{'-'*8} TransitionGroup {'-'*8}\nprecursor chromatograms: {len(self.precursorChroms)}\ntransition chromatograms: {len(self.transitionChroms)}\nprecursor mobilograms: {len(self.precursorMobilos)}\ntransition mobilograms: {len(self.transitionMobilos)}\nprecursor spectra: {len(self.precursorSpectra)}\ntransition spectra: {len(self.transitionSpectra)}\n{self.protein}"
+
+    @property
+    def protein(self):
+        """
+        Returns the protein associated with this transition group.
+        """
+        return self._protein
+
+    @protein.setter
+    def protein(self, value):
+        """
+        Sets the protein associated with this transition group.
+        """
+        self._protein = value
+
+
+    @classmethod
+    def from_feature_map(cls, feature_map: FeatureMap):
+        """
+        Creates a TransitionGroup object from a pandas DataFrame containing feature information.
+
+        Args:
+            feature_map (FeatureMap): A FeatureMap containing mass spec feature information.
+
+        Returns:
+            cls: A TransitionGroup object.
+        """
+        precursorChroms = feature_map.get_precursor_chromatograms()
+        transitionChroms = feature_map.get_transition_chromatograms()
+        if feature_map.has_im:
+            precursorMobilos = feature_map.get_precursor_mobilograms()
+            transitionMobilos = feature_map.get_transition_mobilograms()
+        else:
+            precursorMobilos = None
+            transitionMobilos = None
+        precursorSpectra = feature_map.get_precursor_spectra()
+        transitionSpectra = feature_map.get_transition_spectra()
+        return cls(precursorChroms, transitionChroms, precursorMobilos, transitionMobilos, precursorSpectra, transitionSpectra)
+
+


### PR DESCRIPTION
I added Mobilogram and Spectrum classes, similar to the Chromatogram class.

I also added a FeatureMap class that is used to store the a feature dataframe (mz, rt, im, intensity, mslevel etc) that is obtained from a targeted extraction experiment. The class has methods to extract chromatograms, mobilgorams, and spectra and stores them in their associated classes.

I modified the TransitionGroup class to load data from a FeatureMap, which then loads the associated precursor and transition chromatograms, mobilograms and spectra into the TransitionGroup. I also added a protein property to attached the Protein class which contains information about the Protein and downstream class levels.