### PR TITLE
[TUTORIAL] quickstart jupyter notebook

### DIFF
--- a/tutorials/01_QuickStart.ipynb
+++ b/tutorials/01_QuickStart.ipynb
@@ -1,0 +1,611 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cd537c30-9bcc-4efd-a749-bac4f6d78241",
+   "metadata": {},
+   "source": [
+    "# **1. QuickStart**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1863fd6-f9ab-497d-851a-6e1273143872",
+   "metadata": {},
+   "source": [
+    "Welcome to MassSeer tutorial notebooks. These notebooks outline how MassSeer can be used as a pipeline in addition to the streamlit interface. Using as a python package allows for reproducibly recording plots. *MassSeer* provides a number of convienice functions for commonly used tasks. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25b6a934-8464-4c4e-9cf7-635d575ac2b6",
+   "metadata": {},
+   "source": [
+    "Below are examples of how to use the a quick visualization of the peptide *NKESPT(UniMod:21)KAIVR(UniMod:267)* with a charge state of *3* from multiple different file inputs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d73019ff-5f54-47cd-b690-29078b242285",
+   "metadata": {},
+   "source": [
+    "#### **Setup**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e6785d91-70c6-4b5d-9f15-71f20c93955e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please run this before executing any cell\n",
+    "import os\n",
+    "os.chdir(\"../tests/test_data/\") #### Insert path to data, for this tutorial we have "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33b5fd05-d733-45e2-ab18-f422f2da1462",
+   "metadata": {},
+   "source": [
+    "## **MassSeer Loaders**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de68037b-5fe6-49f3-a29e-6801ce3f4c9c",
+   "metadata": {},
+   "source": [
+    "*MassSeer* supports several methods of loading chromatograms the most common of which are outlined below.\n",
+    "\n",
+    "1. `SqMassLoader` - Loads chromatograms from a `.osw` and a `.sqMass` file.\n",
+    "2. ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04faa2e0-e9fa-4a15-9661-09675f824f26",
+   "metadata": {},
+   "source": [
+    "## **`plotChromatogram()`**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb563f73-192a-46f8-b9e9-4a01dac75755",
+   "metadata": {},
+   "source": [
+    "Most loaders have a `plotChromatogram()` function implemented which provides a wrapper around the plotting interface. The required inputs for this function are a `peptideSequence` and a `charge state`. This function returns an interactive plot of the specified peptide. More details on this function can be accessed using python's built-in `help()` function as shown below.   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "46518636-91d0-458c-8b3a-48897932091b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on function plotChromatogram in module massseer.loaders.SqMassLoader:\n",
+      "\n",
+      "plotChromatogram(self, seq: str, charge: int, includeBoundaries: bool = True, include_ms1: bool = False, smooth: bool = True, sgolay_polynomial_order: int = 3, sgolay_frame_length: int = 11, scale_intensity: bool = False) -> 'bokeh.plotting.figure.Figure'\n",
+      "    Plots a chromatogram for a given peptide sequence and charge state for a given run\n",
+      "    \n",
+      "    Args:\n",
+      "        loader (SqMassLoader): Instance of SqMassLoader\n",
+      "        seq (str): Peptide sequence\n",
+      "        charge (int): Charge state\n",
+      "        includeBoundaries (bool, optional): Whether to include peak boundaries. Defaults to True.\n",
+      "        include_ms1 (bool, optional): Whether to include MS1 data. Defaults to False.\n",
+      "        smooth (bool, optional): Whether to smooth the chromatogram. Defaults to True.\n",
+      "        sgolay_polynomial_order (int, optional): Order of the polynomial to use for smoothing. Defaults to 3.\n",
+      "        sgolay_frame_length (int, optional): Frame length to use for smoothing. Defaults to 11.\n",
+      "        scale_intensity (bool, optional): Whether to scale the intensity of the chromatogram such that all chromatograms are individually normalized to 1. Defaults to False.\n",
+      "    Returns: \n",
+      "        bokeh.plotting.figure.Figure: Bokeh figure object\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from massseer.loaders.SqMassLoader import SqMassLoader\n",
+    "help(SqMassLoader.plotChromatogram)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf3a9fc1-4a31-4611-9310-9057d1d77fec",
+   "metadata": {},
+   "source": [
+    "**Note:** All *MassSeer* functions and classes have a doctring attached to them which can be accessed using the `help()` buit in function. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8981e2f4-dc2e-4108-a099-363fd6d068e2",
+   "metadata": {},
+   "source": [
+    "### **Visualizing OpenSwath Chromatograms**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dca80c3-5161-4238-bd3e-84040d26c6fc",
+   "metadata": {},
+   "source": [
+    "The `SqMassLoader` class can be used to visualize OpenSwath results. An example using the `SqMassLoader` `plotChromatogram()` function is shown below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49092292-c1d1-4614-ac17-554022ce3d2e",
+   "metadata": {},
+   "source": [
+    "#### **Step #1: Initialize the SqMassLoader Object**"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "c7ba89ae-ed46-4efa-b87b-e7350734b729",
+   "metadata": {},
+   "source": [
+    "Here the `SqMassLoader` object is initialized from the test results. Note that depending on the size of your `.osw` initialization can take a bit of time since all of the meta information is loaded for faster data access.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8b6839d8-e12c-4beb-978f-0c92f03b8c42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from massseer.loaders.SqMassLoader import SqMassLoader\n",
+    "oswLoader = SqMassLoader(rsltsFile='osw/test_data.osw', transitionFiles='xics/test_chrom_1.sqMass')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e9bf988-c257-4dee-95fb-a63c6f5296a6",
+   "metadata": {},
+   "source": [
+    "#### **Step #2: Plot a Chromatogram**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22a6fa09-d2e5-42d2-b46c-68766c6f0604",
+   "metadata": {},
+   "source": [
+    "As a demonstration here a chromatogram and the features found by OpenSwath are plotted. The raw chromatogram is plotted since `smooth` is `False`. Note that `smooth` and `includeBoundaries` are both optional arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7d1b07fe-6839-4700-905a-a9ea706dcba5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"bk-root\">\n",
+       "        <a href=\"https://bokeh.org\" target=\"_blank\" class=\"bk-logo bk-logo-small bk-logo-notebook\"></a>\n",
+       "        <span id=\"1002\">Loading BokehJS ...</span>\n",
+       "    </div>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "(function(root) {\n",
+       "  function now() {\n",
+       "    return new Date();\n",
+       "  }\n",
+       "\n",
+       "  const force = true;\n",
+       "\n",
+       "  if (typeof root._bokeh_onload_callbacks === \"undefined\" || force === true) {\n",
+       "    root._bokeh_onload_callbacks = [];\n",
+       "    root._bokeh_is_loading = undefined;\n",
+       "  }\n",
+       "\n",
+       "const JS_MIME_TYPE = 'application/javascript';\n",
+       "  const HTML_MIME_TYPE = 'text/html';\n",
+       "  const EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json';\n",
+       "  const CLASS_NAME = 'output_bokeh rendered_html';\n",
+       "\n",
+       "  /**\n",
+       "   * Render data to the DOM node\n",
+       "   */\n",
+       "  function render(props, node) {\n",
+       "    const script = document.createElement(\"script\");\n",
+       "    node.appendChild(script);\n",
+       "  }\n",
+       "\n",
+       "  /**\n",
+       "   * Handle when an output is cleared or removed\n",
+       "   */\n",
+       "  function handleClearOutput(event, handle) {\n",
+       "    const cell = handle.cell;\n",
+       "\n",
+       "    const id = cell.output_area._bokeh_element_id;\n",
+       "    const server_id = cell.output_area._bokeh_server_id;\n",
+       "    // Clean up Bokeh references\n",
+       "    if (id != null && id in Bokeh.index) {\n",
+       "      Bokeh.index[id].model.document.clear();\n",
+       "      delete Bokeh.index[id];\n",
+       "    }\n",
+       "\n",
+       "    if (server_id !== undefined) {\n",
+       "      // Clean up Bokeh references\n",
+       "      const cmd_clean = \"from bokeh.io.state import curstate; print(curstate().uuid_to_server['\" + server_id + \"'].get_sessions()[0].document.roots[0]._id)\";\n",
+       "      cell.notebook.kernel.execute(cmd_clean, {\n",
+       "        iopub: {\n",
+       "          output: function(msg) {\n",
+       "            const id = msg.content.text.trim();\n",
+       "            if (id in Bokeh.index) {\n",
+       "              Bokeh.index[id].model.document.clear();\n",
+       "              delete Bokeh.index[id];\n",
+       "            }\n",
+       "          }\n",
+       "        }\n",
+       "      });\n",
+       "      // Destroy server and session\n",
+       "      const cmd_destroy = \"import bokeh.io.notebook as ion; ion.destroy_server('\" + server_id + \"')\";\n",
+       "      cell.notebook.kernel.execute(cmd_destroy);\n",
+       "    }\n",
+       "  }\n",
+       "\n",
+       "  /**\n",
+       "   * Handle when a new output is added\n",
+       "   */\n",
+       "  function handleAddOutput(event, handle) {\n",
+       "    const output_area = handle.output_area;\n",
+       "    const output = handle.output;\n",
+       "\n",
+       "    // limit handleAddOutput to display_data with EXEC_MIME_TYPE content only\n",
+       "    if ((output.output_type != \"display_data\") || (!Object.prototype.hasOwnProperty.call(output.data, EXEC_MIME_TYPE))) {\n",
+       "      return\n",
+       "    }\n",
+       "\n",
+       "    const toinsert = output_area.element.find(\".\" + CLASS_NAME.split(' ')[0]);\n",
+       "\n",
+       "    if (output.metadata[EXEC_MIME_TYPE][\"id\"] !== undefined) {\n",
+       "      toinsert[toinsert.length - 1].firstChild.textContent = output.data[JS_MIME_TYPE];\n",
+       "      // store reference to embed id on output_area\n",
+       "      output_area._bokeh_element_id = output.metadata[EXEC_MIME_TYPE][\"id\"];\n",
+       "    }\n",
+       "    if (output.metadata[EXEC_MIME_TYPE][\"server_id\"] !== undefined) {\n",
+       "      const bk_div = document.createElement(\"div\");\n",
+       "      bk_div.innerHTML = output.data[HTML_MIME_TYPE];\n",
+       "      const script_attrs = bk_div.children[0].attributes;\n",
+       "      for (let i = 0; i < script_attrs.length; i++) {\n",
+       "        toinsert[toinsert.length - 1].firstChild.setAttribute(script_attrs[i].name, script_attrs[i].value);\n",
+       "        toinsert[toinsert.length - 1].firstChild.textContent = bk_div.children[0].textContent\n",
+       "      }\n",
+       "      // store reference to server id on output_area\n",
+       "      output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE][\"server_id\"];\n",
+       "    }\n",
+       "  }\n",
+       "\n",
+       "  function register_renderer(events, OutputArea) {\n",
+       "\n",
+       "    function append_mime(data, metadata, element) {\n",
+       "      // create a DOM node to render to\n",
+       "      const toinsert = this.create_output_subarea(\n",
+       "        metadata,\n",
+       "        CLASS_NAME,\n",
+       "        EXEC_MIME_TYPE\n",
+       "      );\n",
+       "      this.keyboard_manager.register_events(toinsert);\n",
+       "      // Render to node\n",
+       "      const props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};\n",
+       "      render(props, toinsert[toinsert.length - 1]);\n",
+       "      element.append(toinsert);\n",
+       "      return toinsert\n",
+       "    }\n",
+       "\n",
+       "    /* Handle when an output is cleared or removed */\n",
+       "    events.on('clear_output.CodeCell', handleClearOutput);\n",
+       "    events.on('delete.Cell', handleClearOutput);\n",
+       "\n",
+       "    /* Handle when a new output is added */\n",
+       "    events.on('output_added.OutputArea', handleAddOutput);\n",
+       "\n",
+       "    /**\n",
+       "     * Register the mime type and append_mime function with output_area\n",
+       "     */\n",
+       "    OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {\n",
+       "      /* Is output safe? */\n",
+       "      safe: true,\n",
+       "      /* Index of renderer in `output_area.display_order` */\n",
+       "      index: 0\n",
+       "    });\n",
+       "  }\n",
+       "\n",
+       "  // register the mime type if in Jupyter Notebook environment and previously unregistered\n",
+       "  if (root.Jupyter !== undefined) {\n",
+       "    const events = require('base/js/events');\n",
+       "    const OutputArea = require('notebook/js/outputarea').OutputArea;\n",
+       "\n",
+       "    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {\n",
+       "      register_renderer(events, OutputArea);\n",
+       "    }\n",
+       "  }\n",
+       "  if (typeof (root._bokeh_timeout) === \"undefined\" || force === true) {\n",
+       "    root._bokeh_timeout = Date.now() + 5000;\n",
+       "    root._bokeh_failed_load = false;\n",
+       "  }\n",
+       "\n",
+       "  const NB_LOAD_WARNING = {'data': {'text/html':\n",
+       "     \"<div style='background-color: #fdd'>\\n\"+\n",
+       "     \"<p>\\n\"+\n",
+       "     \"BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \\n\"+\n",
+       "     \"may be due to a slow or bad network connection. Possible fixes:\\n\"+\n",
+       "     \"</p>\\n\"+\n",
+       "     \"<ul>\\n\"+\n",
+       "     \"<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\\n\"+\n",
+       "     \"<li>use INLINE resources instead, as so:</li>\\n\"+\n",
+       "     \"</ul>\\n\"+\n",
+       "     \"<code>\\n\"+\n",
+       "     \"from bokeh.resources import INLINE\\n\"+\n",
+       "     \"output_notebook(resources=INLINE)\\n\"+\n",
+       "     \"</code>\\n\"+\n",
+       "     \"</div>\"}};\n",
+       "\n",
+       "  function display_loaded() {\n",
+       "    const el = document.getElementById(\"1002\");\n",
+       "    if (el != null) {\n",
+       "      el.textContent = \"BokehJS is loading...\";\n",
+       "    }\n",
+       "    if (root.Bokeh !== undefined) {\n",
+       "      if (el != null) {\n",
+       "        el.textContent = \"BokehJS \" + root.Bokeh.version + \" successfully loaded.\";\n",
+       "      }\n",
+       "    } else if (Date.now() < root._bokeh_timeout) {\n",
+       "      setTimeout(display_loaded, 100)\n",
+       "    }\n",
+       "  }\n",
+       "\n",
+       "  function run_callbacks() {\n",
+       "    try {\n",
+       "      root._bokeh_onload_callbacks.forEach(function(callback) {\n",
+       "        if (callback != null)\n",
+       "          callback();\n",
+       "      });\n",
+       "    } finally {\n",
+       "      delete root._bokeh_onload_callbacks\n",
+       "    }\n",
+       "    console.debug(\"Bokeh: all callbacks have finished\");\n",
+       "  }\n",
+       "\n",
+       "  function load_libs(css_urls, js_urls, callback) {\n",
+       "    if (css_urls == null) css_urls = [];\n",
+       "    if (js_urls == null) js_urls = [];\n",
+       "\n",
+       "    root._bokeh_onload_callbacks.push(callback);\n",
+       "    if (root._bokeh_is_loading > 0) {\n",
+       "      console.debug(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n",
+       "      return null;\n",
+       "    }\n",
+       "    if (js_urls == null || js_urls.length === 0) {\n",
+       "      run_callbacks();\n",
+       "      return null;\n",
+       "    }\n",
+       "    console.debug(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n",
+       "    root._bokeh_is_loading = css_urls.length + js_urls.length;\n",
+       "\n",
+       "    function on_load() {\n",
+       "      root._bokeh_is_loading--;\n",
+       "      if (root._bokeh_is_loading === 0) {\n",
+       "        console.debug(\"Bokeh: all BokehJS libraries/stylesheets loaded\");\n",
+       "        run_callbacks()\n",
+       "      }\n",
+       "    }\n",
+       "\n",
+       "    function on_error(url) {\n",
+       "      console.error(\"failed to load \" + url);\n",
+       "    }\n",
+       "\n",
+       "    for (let i = 0; i < css_urls.length; i++) {\n",
+       "      const url = css_urls[i];\n",
+       "      const element = document.createElement(\"link\");\n",
+       "      element.onload = on_load;\n",
+       "      element.onerror = on_error.bind(null, url);\n",
+       "      element.rel = \"stylesheet\";\n",
+       "      element.type = \"text/css\";\n",
+       "      element.href = url;\n",
+       "      console.debug(\"Bokeh: injecting link tag for BokehJS stylesheet: \", url);\n",
+       "      document.body.appendChild(element);\n",
+       "    }\n",
+       "\n",
+       "    for (let i = 0; i < js_urls.length; i++) {\n",
+       "      const url = js_urls[i];\n",
+       "      const element = document.createElement('script');\n",
+       "      element.onload = on_load;\n",
+       "      element.onerror = on_error.bind(null, url);\n",
+       "      element.async = false;\n",
+       "      element.src = url;\n",
+       "      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n",
+       "      document.head.appendChild(element);\n",
+       "    }\n",
+       "  };\n",
+       "\n",
+       "  function inject_raw_css(css) {\n",
+       "    const element = document.createElement(\"style\");\n",
+       "    element.appendChild(document.createTextNode(css));\n",
+       "    document.body.appendChild(element);\n",
+       "  }\n",
+       "\n",
+       "  const js_urls = [\"https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-gl-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-2.4.3.min.js\"];\n",
+       "  const css_urls = [];\n",
+       "\n",
+       "  const inline_js = [    function(Bokeh) {\n",
+       "      Bokeh.set_log_level(\"info\");\n",
+       "    },\n",
+       "function(Bokeh) {\n",
+       "    }\n",
+       "  ];\n",
+       "\n",
+       "  function run_inline_js() {\n",
+       "    if (root.Bokeh !== undefined || force === true) {\n",
+       "          for (let i = 0; i < inline_js.length; i++) {\n",
+       "      inline_js[i].call(root, root.Bokeh);\n",
+       "    }\n",
+       "if (force === true) {\n",
+       "        display_loaded();\n",
+       "      }} else if (Date.now() < root._bokeh_timeout) {\n",
+       "      setTimeout(run_inline_js, 100);\n",
+       "    } else if (!root._bokeh_failed_load) {\n",
+       "      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n",
+       "      root._bokeh_failed_load = true;\n",
+       "    } else if (force !== true) {\n",
+       "      const cell = $(document.getElementById(\"1002\")).parents('.cell').data().cell;\n",
+       "      cell.output_area.append_execute_result(NB_LOAD_WARNING)\n",
+       "    }\n",
+       "  }\n",
+       "\n",
+       "  if (root._bokeh_is_loading === 0) {\n",
+       "    console.debug(\"Bokeh: BokehJS loaded, going straight to plotting\");\n",
+       "    run_inline_js();\n",
+       "  } else {\n",
+       "    load_libs(css_urls, js_urls, function() {\n",
+       "      console.debug(\"Bokeh: BokehJS plotting callback run at\", now());\n",
+       "      run_inline_js();\n",
+       "    });\n",
+       "  }\n",
+       "}(window));"
+      ],
+      "application/vnd.bokehjs_load.v0+json": "(function(root) {\n  function now() {\n    return new Date();\n  }\n\n  const force = true;\n\n  if (typeof root._bokeh_onload_callbacks === \"undefined\" || force === true) {\n    root._bokeh_onload_callbacks = [];\n    root._bokeh_is_loading = undefined;\n  }\n\n\n  if (typeof (root._bokeh_timeout) === \"undefined\" || force === true) {\n    root._bokeh_timeout = Date.now() + 5000;\n    root._bokeh_failed_load = false;\n  }\n\n  const NB_LOAD_WARNING = {'data': {'text/html':\n     \"<div style='background-color: #fdd'>\\n\"+\n     \"<p>\\n\"+\n     \"BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \\n\"+\n     \"may be due to a slow or bad network connection. Possible fixes:\\n\"+\n     \"</p>\\n\"+\n     \"<ul>\\n\"+\n     \"<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\\n\"+\n     \"<li>use INLINE resources instead, as so:</li>\\n\"+\n     \"</ul>\\n\"+\n     \"<code>\\n\"+\n     \"from bokeh.resources import INLINE\\n\"+\n     \"output_notebook(resources=INLINE)\\n\"+\n     \"</code>\\n\"+\n     \"</div>\"}};\n\n  function display_loaded() {\n    const el = document.getElementById(\"1002\");\n    if (el != null) {\n      el.textContent = \"BokehJS is loading...\";\n    }\n    if (root.Bokeh !== undefined) {\n      if (el != null) {\n        el.textContent = \"BokehJS \" + root.Bokeh.version + \" successfully loaded.\";\n      }\n    } else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(display_loaded, 100)\n    }\n  }\n\n  function run_callbacks() {\n    try {\n      root._bokeh_onload_callbacks.forEach(function(callback) {\n        if (callback != null)\n          callback();\n      });\n    } finally {\n      delete root._bokeh_onload_callbacks\n    }\n    console.debug(\"Bokeh: all callbacks have finished\");\n  }\n\n  function load_libs(css_urls, js_urls, callback) {\n    if (css_urls == null) css_urls = [];\n    if (js_urls == null) js_urls = [];\n\n    root._bokeh_onload_callbacks.push(callback);\n    if (root._bokeh_is_loading > 0) {\n      console.debug(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n      return null;\n    }\n    if (js_urls == null || js_urls.length === 0) {\n      run_callbacks();\n      return null;\n    }\n    console.debug(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n    root._bokeh_is_loading = css_urls.length + js_urls.length;\n\n    function on_load() {\n      root._bokeh_is_loading--;\n      if (root._bokeh_is_loading === 0) {\n        console.debug(\"Bokeh: all BokehJS libraries/stylesheets loaded\");\n        run_callbacks()\n      }\n    }\n\n    function on_error(url) {\n      console.error(\"failed to load \" + url);\n    }\n\n    for (let i = 0; i < css_urls.length; i++) {\n      const url = css_urls[i];\n      const element = document.createElement(\"link\");\n      element.onload = on_load;\n      element.onerror = on_error.bind(null, url);\n      element.rel = \"stylesheet\";\n      element.type = \"text/css\";\n      element.href = url;\n      console.debug(\"Bokeh: injecting link tag for BokehJS stylesheet: \", url);\n      document.body.appendChild(element);\n    }\n\n    for (let i = 0; i < js_urls.length; i++) {\n      const url = js_urls[i];\n      const element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error.bind(null, url);\n      element.async = false;\n      element.src = url;\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n  };\n\n  function inject_raw_css(css) {\n    const element = document.createElement(\"style\");\n    element.appendChild(document.createTextNode(css));\n    document.body.appendChild(element);\n  }\n\n  const js_urls = [\"https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-gl-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-2.4.3.min.js\"];\n  const css_urls = [];\n\n  const inline_js = [    function(Bokeh) {\n      Bokeh.set_log_level(\"info\");\n    },\nfunction(Bokeh) {\n    }\n  ];\n\n  function run_inline_js() {\n    if (root.Bokeh !== undefined || force === true) {\n          for (let i = 0; i < inline_js.length; i++) {\n      inline_js[i].call(root, root.Bokeh);\n    }\nif (force === true) {\n        display_loaded();\n      }} else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(run_inline_js, 100);\n    } else if (!root._bokeh_failed_load) {\n      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n      root._bokeh_failed_load = true;\n    } else if (force !== true) {\n      const cell = $(document.getElementById(\"1002\")).parents('.cell').data().cell;\n      cell.output_area.append_execute_result(NB_LOAD_WARNING)\n    }\n  }\n\n  if (root._bokeh_is_loading === 0) {\n    console.debug(\"Bokeh: BokehJS loaded, going straight to plotting\");\n    run_inline_js();\n  } else {\n    load_libs(css_urls, js_urls, function() {\n      console.debug(\"Bokeh: BokehJS plotting callback run at\", now());\n      run_inline_js();\n    });\n  }\n}(window));"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "  <div class=\"bk-root\" id=\"a023eb19-4fe6-4d03-a339-cd4f4a832b28\" data-root-id=\"1003\"></div>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "(function(root) {\n",
+       "  function embed_document(root) {\n",
+       "  const docs_json = {\"ac525c78-ac23-4720-bdb5-6ac5a440f50d\":{\"defs\":[],\"roots\":{\"references\":[{\"attributes\":{\"below\":[{\"id\":\"1012\"}],\"center\":[{\"id\":\"1015\"},{\"id\":\"1019\"}],\"height\":400,\"left\":[{\"id\":\"1016\"}],\"renderers\":[{\"id\":\"1042\"},{\"id\":\"1049\"},{\"id\":\"1056\"},{\"id\":\"1063\"},{\"id\":\"1070\"},{\"id\":\"1077\"},{\"id\":\"1090\"},{\"id\":\"1096\"},{\"id\":\"1102\"},{\"id\":\"1109\"},{\"id\":\"1115\"},{\"id\":\"1121\"},{\"id\":\"1128\"},{\"id\":\"1134\"},{\"id\":\"1140\"},{\"id\":\"1147\"},{\"id\":\"1153\"},{\"id\":\"1159\"}],\"right\":[{\"id\":\"1036\"}],\"sizing_mode\":\"scale_width\",\"title\":{\"id\":\"1163\"},\"toolbar\":{\"id\":\"1028\"},\"toolbar_location\":\"above\",\"width\":800,\"x_range\":{\"id\":\"1004\"},\"x_scale\":{\"id\":\"1008\"},\"y_range\":{\"id\":\"1006\"},\"y_scale\":{\"id\":\"1010\"}},\"id\":\"1003\",\"subtype\":\"Figure\",\"type\":\"Plot\"},{\"attributes\":{\"axis_label\":\"Intensity\",\"coordinates\":null,\"formatter\":{\"id\":\"1166\"},\"group\":null,\"major_label_policy\":{\"id\":\"1167\"},\"ticker\":{\"id\":\"1017\"}},\"id\":\"1016\",\"type\":\"LinearAxis\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#2ca02c\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1068\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"1174\",\"type\":\"Selection\"},{\"attributes\":{},\"id\":\"1004\",\"type\":\"DataRange1d\"},{\"attributes\":{\"data\":{\"Intensity\":[15781.0],\"bottom_int\":[0],\"leftWidth\":[818.476013183594],\"ms2_mscore\":[0.07677153679402818],\"rightWidth\":[847.557983398438]},\"selected\":{\"id\":\"1184\"},\"selection_policy\":{\"id\":\"1183\"}},\"id\":\"1085\",\"type\":\"ColumnDataSource\"},{\"attributes\":{},\"id\":\"1013\",\"type\":\"BasicTicker\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#1B9E77\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#1B9E77\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#1B9E77\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1088\",\"type\":\"VBar\"},{\"attributes\":{},\"id\":\"1021\",\"type\":\"WheelZoomTool\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1044\"},\"glyph\":{\"id\":\"1046\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1048\"},\"nonselection_glyph\":{\"id\":\"1047\"},\"view\":{\"id\":\"1050\"}},\"id\":\"1049\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"data\":{\"precursor_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_charge\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"x\":{\"__ndarray__\":\"mpmZmZkJgEBmZmZmZiaAQDMzMzMzQ4BAzczMzMxggECamZmZmX2AQGZmZmZmmoBAAAAAAAC4gEDNzMzMzNSAQJqZmZmZ8YBAMzMzMzMPgUAAAAAAACyBQM3MzMzMSIFAZmZmZmZmgUAzMzMzM4OBQAAAAAAAoIFAmpmZmZm9gUBmZmZmZtqBQDMzMzMz94FAzczMzMwUgkCamZmZmTGCQDMzMzMzT4JAAAAAAABsgkDNzMzMzIiCQGZmZmZmpoJAMzMzMzPDgkAAAAAAAOCCQJqZmZmZ/YJAZmZmZmYag0AzMzMzMzeDQM3MzMzMVINAmpmZmZlxg0BmZmZmZo6DQAAAAAAArINAzczMzMzIg0CamZmZmeWDQDMzMzMzA4RAAAAAAAAghEDNzMzMzDyEQGZmZmZmWoRAMzMzMzN3hEAAAAAAAJSEQJqZmZmZsYRAZmZmZmbOhEAAAAAAAOyEQM3MzMzMCIVAmpmZmZklhUAzMzMzM0OFQAAAAAAAYIVAzczMzMx8hUBmZmZmZpqFQDMzMzMzt4VAAAAAAADUhUCamZmZmfGFQGZmZmZmDoZAMzMzMzMrhkDNzMzMzEiGQJqZmZmZZYZAZmZmZmaChkAAAAAAAKCGQM3MzMzMvIZAmpmZmZnZhkAzMzMzM/eGQAAAAAAAFIdAzczMzMwwh0BmZmZmZk6HQDMzMzMza4dAzczMzMyIh0CamZmZmaWHQGZmZmZmwodAAAAAAADgh0DNzMzMzPyHQJqZmZmZGYhAMzMzMzM3iEAAAAAAAFSIQM3MzMzMcIhAZmZmZmaOiEAzMzMzM6uIQAAAAAAAyIhAmpmZmZnliEBmZmZmZgKJQDMzMzMzH4lAzczMzMw8iUCamZmZmVmJQGZmZmZmdolAAAAAAACUiUDNzMzMzLCJQJqZmZmZzYlAMzMzMzPriUAAAAAAAAiKQJqZmZmZJYpAZmZmZmZCikAzMzMzM1+KQM3MzMzMfIpAmpmZmZmZikBmZmZmZraKQAAAAAAA1IpAzczMzMzwikCamZmZmQ2LQDMzMzMzK4tAAAAAAABIi0DNzMzMzGSLQGZmZmZmgotAMzMzMzOfi0AAAAAAALyLQJqZmZmZ2YtAZmZmZmb2i0AzMzMzMxOMQM3MzMzMMIxAmpmZmZlNjEAzMzMzM2uMQAAAAAAAiIxAzczMzMykjEBmZmZmZsKMQDMzMzMz34xAAAAAAAD8jECamZmZmRmNQGZmZmZmNo1AMzMzMzNTjUDNzMzMzHCNQJqZmZmZjY1AZmZmZmaqjUAAAAAAAMiNQM3MzMzM5I1AmpmZmZkBjkAzMzMzMx+OQAAAAAAAPI5AzczMzMxYjkBmZmZmZnaOQDMzMzMzk45AAAAAAACwjkCamZmZmc2OQGZmZmZm6o5AMzMzMzMHj0DNzMzMzCSPQJqZmZmZQY9AMzMzMzNfj0AAAAAAAHyPQM3MzMzMmI9AZmZmZma2j0AzMzMzM9OPQAAAAAAA8I9AzczMzMwGkEAzMzMzMxWQQJqZmZmZI5BAZmZmZmYykEDNzMzMzECQQDMzMzMzT5BAAAAAAABekEBmZmZmZmyQQM3MzMzMepBAmpmZmZmJkEAAAAAAAJiQQM3MzMzMppBAMzMzMzO1kECamZmZmcOQQGZmZmZm0pBAzczMzMzgkEAzMzMzM++QQAAAAAAA/pBAZmZmZmYMkUDNzMzMzBqRQJqZmZmZKZFAAAAAAAA4kUBmZmZmZkaRQDMzMzMzVZFAmpmZmZljkUAAAAAAAHKRQM3MzMzMgJFAMzMzMzOPkUCamZmZmZ2RQGZmZmZmrJFAzczMzMy6kUAzMzMzM8mRQAAAAAAA2JFAZmZmZmbmkUAzMzMzM/WRQJqZmZmZA5JAAAAAAAASkkDNzMzMzCCSQDMzMzMzL5JAmpmZmZk9kkBmZmZmZkySQM3MzMzMWpJAMzMzMzNpkkAAAAAAAHiSQGZmZmZmhpJAzczMzMyUkkCamZmZmaOSQAAAAAAAspJAZmZmZmbAkkAzMzMzM8+SQJqZmZmZ3ZJAAAAAAADskkA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]},\"y\":{\"__ndarray__\":\"AAAAAAAAAAB1VmKN0z9aQFOrYtn5/2RAdVZijdM/WkAvMYFIEABVQHUdv2U5AEVAHLoYM3iAT0C28zVf559nQBy6GDN4gE9AHLoYM3iAT0CT1//8MoBnQHUdv2U5AEVAdVZijdM/WkAvMYFIEABVQPJvEJtCADVALzGBSBAAVUCqWTzDE4BfQJt6cbgG4GRAU6ti2fn/ZECbenG4BuBkQLbzNV/nn2dAdVZijdM/WkB1VmKN0z9aQC8xgUgQAFVAdR2/ZTkARUDybxCbQgA1QM3K85tIAFpALzGBSBAAVUB1Hb9lOQBFQAAAAAAAAAAA8m8Qm0IANUDybxCbQgA1QBy6GDN4gE9ALzGBSBAAVUDNyvObSABaQKpZPMMTgF9ALzGBSBAAVUAvMYFIEABVQBy6GDN4gE9AHLoYM3iAT0CqWTzDE4BfQHUdv2U5AEVAdR2/ZTkARUDybxCbQgA1QHUdv2U5AEVA8m8Qm0IANUB1Hb9lOQBFQC8xgUgQAFVAdVZijdM/WkCqWTzDE4BfQGpMmQunP2pALzGBSBAAVUAvMYFIEABVQBy6GDN4gE9AAAAAAAAAAAAvMYFIEABVQIMjLib/X2JAdR2/ZTkARUAAAAAAAAAAABy6GDN4gE9A8m8Qm0IANUAcuhgzeIBPQHUdv2U5AEVAdVZijdM/WkDybxCbQgA1QAAAAAAAAAAAdVZijdM/WkB1Hb9lOQBFQPJvEJtCADVAdVZijdM/WkB1VmKN0z9aQPJvEJtCADVAdVZijdM/WkB1VmKN0z9aQFOrYtn5/2RAtvM1X+efZ0CJWxmDMEBiQHVWYo3TP1pAdR2/ZTkARUB1VmKN0z9aQKWDHiwdQF9AAAAAAAAAAACDIy4m/19iQHVWYo3TP1pAHLoYM3iAT0AvMYFIEABVQC8xgUgQAFVAdVZijdM/WkCJWxmDMEBiQKWDHiwdQF9ALzGBSBAAVUAvMYFIEABVQIl8WBbu73BAWeybuQHgeEA8Sm43t4eDQIkrBWq0/5NAx5hJnj+QnUDxtGrg3qOfQI65sNLXq5tASlb5utpfiUD1a/uQ3b98QFOrYtn5/2RAYUqngxxgckC28zVf559nQLLQ990T8HRAmh/6Obf/dEB6+HPkMGBvQKpZPMMTgF9AHLoYM3iAT0B1Hb9lOQBFQLbzNV/nn2dAqlk8wxOAX0BTq2LZ+f9kQAAAAAAAAAAAdR2/ZTkARUAcuhgzeIBPQKpZPMMTgF9AtvM1X+efZ0DN9Izc8N9sQHVWYo3TP1pAqlk8wxOAX0CDIy4m/19iQIMjLib/X2JAdR2/ZTkARUB1VmKN0z9aQBy6GDN4gE9AHLoYM3iAT0DNyvObSABaQC8xgUgQAFVAdVZijdM/WkB1VmKN0z9aQBy6GDN4gE9AzfSM3PDfbEAvMYFIEABVQJt6cbgG4GRAqlk8wxOAX0B1VmKN0z9aQKpZPMMTgF9AzfSM3PDfbEBTq2LZ+f9kQIMjLib/X2JAgyMuJv9fYkCqWTzDE4BfQJt6cbgG4GRA3Y4TmqEvekBxwT+5HYB3QJpBNxgcgG9ALzGBSBAAVUCqWTzDE4BfQKpZPMMTgF9AU6ti2fn/ZECqWTzDE4BfQKpZPMMTgF9AgyMuJv9fYkB1Hb9lOQBFQKpZPMMTgF9A8m8Qm0IANUCqWTzDE4BfQHVWYo3TP1pAHLoYM3iAT0CqWTzDE4BfQIMjLib/X2JAtvM1X+efZ0CDIy4m/19iQIMjLib/X2JAqlk8wxOAX0BTq2LZ+f9kQC8xgUgQAFVALzGBSBAAVUAcuhgzeIBPQM30jNzw32xAHLoYM3iAT0B1VmKN0z9aQHVWYo3TP1pAqlk8wxOAX0B1VmKN0z9aQBy6GDN4gE9A8m8Qm0IANUAAAAAAAAAAABy6GDN4gE9AHLoYM3iAT0AcuhgzeIBPQHVWYo3TP1pAqlk8wxOAX0AcuhgzeIBPQHUdv2U5AEVAougDC1kgakCqWTzDE4BfQFXrcew/gHNAiXxYFu7vcECaQTcYHIBvQCnMDSQxsHNAtvM1X+efZ0A=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]}},\"selected\":{\"id\":\"1182\"},\"selection_policy\":{\"id\":\"1181\"}},\"id\":\"1072\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"line_alpha\":0.5,\"line_color\":\"#aec7e8\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1046\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"1017\",\"type\":\"BasicTicker\"},{\"attributes\":{\"axis_label\":\"Retention Time\",\"coordinates\":null,\"formatter\":{\"id\":\"1169\"},\"group\":null,\"major_label_policy\":{\"id\":\"1170\"},\"ticker\":{\"id\":\"1013\"}},\"id\":\"1012\",\"type\":\"LinearAxis\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#1B9E77\"},\"hatch_color\":{\"value\":\"#1B9E77\"},\"line_color\":{\"value\":\"#1B9E77\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1087\",\"type\":\"VBar\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#ffbb78\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1062\",\"type\":\"Line\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1104\"},\"glyph\":{\"id\":\"1106\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1108\"},\"nonselection_glyph\":{\"id\":\"1107\"},\"view\":{\"id\":\"1110\"}},\"id\":\"1109\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#1B9E77\"},\"hatch_color\":{\"value\":\"#1B9E77\"},\"line_color\":{\"value\":\"#1B9E77\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1093\",\"type\":\"VBar\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#98df8a\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1076\",\"type\":\"Line\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1072\"},\"glyph\":{\"id\":\"1074\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1076\"},\"nonselection_glyph\":{\"id\":\"1075\"},\"view\":{\"id\":\"1078\"}},\"id\":\"1077\",\"type\":\"GlyphRenderer\"},{\"attributes\":{},\"id\":\"1175\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1058\"},\"glyph\":{\"id\":\"1060\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1062\"},\"nonselection_glyph\":{\"id\":\"1061\"},\"view\":{\"id\":\"1064\"}},\"id\":\"1063\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#D95F02\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#D95F02\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#D95F02\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1108\",\"type\":\"VBar\"},{\"attributes\":{\"label\":{\"value\":\"y4^1\"},\"renderers\":[{\"id\":\"1042\"}]},\"id\":\"1079\",\"type\":\"LegendItem\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1085\"},\"glyph\":{\"id\":\"1087\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1089\"},\"nonselection_glyph\":{\"id\":\"1088\"},\"view\":{\"id\":\"1091\"}},\"id\":\"1090\",\"type\":\"GlyphRenderer\"},{\"attributes\":{},\"id\":\"1176\",\"type\":\"Selection\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#1B9E77\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#1B9E77\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#1B9E77\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1089\",\"type\":\"VBar\"},{\"attributes\":{\"source\":{\"id\":\"1065\"}},\"id\":\"1071\",\"type\":\"CDSView\"},{\"attributes\":{},\"id\":\"1023\",\"type\":\"SaveTool\"},{\"attributes\":{\"label\":{\"value\":\"y2^1\"},\"renderers\":[{\"id\":\"1070\"}]},\"id\":\"1083\",\"type\":\"LegendItem\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1085\"},\"glyph\":{\"id\":\"1093\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1095\"},\"nonselection_glyph\":{\"id\":\"1094\"},\"view\":{\"id\":\"1097\"}},\"id\":\"1096\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"source\":{\"id\":\"1085\"}},\"id\":\"1091\",\"type\":\"CDSView\"},{\"attributes\":{},\"id\":\"1020\",\"type\":\"PanTool\"},{\"attributes\":{\"line_alpha\":0.5,\"line_color\":\"#2ca02c\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1067\",\"type\":\"Line\"},{\"attributes\":{\"line_alpha\":0.5,\"line_color\":\"#98df8a\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1074\",\"type\":\"Line\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#D95F02\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#D95F02\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#D95F02\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1113\",\"type\":\"VBar\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#2ca02c\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1069\",\"type\":\"Line\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#1B9E77\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#1B9E77\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#1B9E77\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1094\",\"type\":\"VBar\"},{\"attributes\":{\"callback\":null,\"names\":[\"leftWidth_apex_point\"],\"tooltips\":[[\"Intensity\",\"@Intensity\"],[\"Left Width\",\"@leftWidth{0.00}\"],[\"Right Width\",\"@rightWidth{0.00}\"],[\"Peak Group Rank\",\"@peakgroup_rank\"],[\"MS2 m-score\",\"@ms2_mscore\"]]},\"id\":\"1161\",\"type\":\"HoverTool\"},{\"attributes\":{},\"id\":\"1187\",\"type\":\"UnionRenderers\"},{\"attributes\":{},\"id\":\"1166\",\"type\":\"BasicTickFormatter\"},{\"attributes\":{},\"id\":\"1188\",\"type\":\"Selection\"},{\"attributes\":{\"axis\":{\"id\":\"1016\"},\"coordinates\":null,\"dimension\":1,\"group\":null,\"ticker\":null},\"id\":\"1019\",\"type\":\"Grid\"},{\"attributes\":{\"label\":{\"value\":\"y5^1\"},\"renderers\":[{\"id\":\"1063\"}]},\"id\":\"1082\",\"type\":\"LegendItem\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#D95F02\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#D95F02\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#D95F02\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1107\",\"type\":\"VBar\"},{\"attributes\":{},\"id\":\"1177\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"data\":{\"precursor_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_charge\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"x\":{\"__ndarray__\":\"mpmZmZkJgEBmZmZmZiaAQDMzMzMzQ4BAzczMzMxggECamZmZmX2AQGZmZmZmmoBAAAAAAAC4gEDNzMzMzNSAQJqZmZmZ8YBAMzMzMzMPgUAAAAAAACyBQM3MzMzMSIFAZmZmZmZmgUAzMzMzM4OBQAAAAAAAoIFAmpmZmZm9gUBmZmZmZtqBQDMzMzMz94FAzczMzMwUgkCamZmZmTGCQDMzMzMzT4JAAAAAAABsgkDNzMzMzIiCQGZmZmZmpoJAMzMzMzPDgkAAAAAAAOCCQJqZmZmZ/YJAZmZmZmYag0AzMzMzMzeDQM3MzMzMVINAmpmZmZlxg0BmZmZmZo6DQAAAAAAArINAzczMzMzIg0CamZmZmeWDQDMzMzMzA4RAAAAAAAAghEDNzMzMzDyEQGZmZmZmWoRAMzMzMzN3hEAAAAAAAJSEQJqZmZmZsYRAZmZmZmbOhEAAAAAAAOyEQM3MzMzMCIVAmpmZmZklhUAzMzMzM0OFQAAAAAAAYIVAzczMzMx8hUBmZmZmZpqFQDMzMzMzt4VAAAAAAADUhUCamZmZmfGFQGZmZmZmDoZAMzMzMzMrhkDNzMzMzEiGQJqZmZmZZYZAZmZmZmaChkAAAAAAAKCGQM3MzMzMvIZAmpmZmZnZhkAzMzMzM/eGQAAAAAAAFIdAzczMzMwwh0BmZmZmZk6HQDMzMzMza4dAzczMzMyIh0CamZmZmaWHQGZmZmZmwodAAAAAAADgh0DNzMzMzPyHQJqZmZmZGYhAMzMzMzM3iEAAAAAAAFSIQM3MzMzMcIhAZmZmZmaOiEAzMzMzM6uIQAAAAAAAyIhAmpmZmZnliEBmZmZmZgKJQDMzMzMzH4lAzczMzMw8iUCamZmZmVmJQGZmZmZmdolAAAAAAACUiUDNzMzMzLCJQJqZmZmZzYlAMzMzMzPriUAAAAAAAAiKQJqZmZmZJYpAZmZmZmZCikAzMzMzM1+KQM3MzMzMfIpAmpmZmZmZikBmZmZmZraKQAAAAAAA1IpAzczMzMzwikCamZmZmQ2LQDMzMzMzK4tAAAAAAABIi0DNzMzMzGSLQGZmZmZmgotAMzMzMzOfi0AAAAAAALyLQJqZmZmZ2YtAZmZmZmb2i0AzMzMzMxOMQM3MzMzMMIxAmpmZmZlNjEAzMzMzM2uMQAAAAAAAiIxAzczMzMykjEBmZmZmZsKMQDMzMzMz34xAAAAAAAD8jECamZmZmRmNQGZmZmZmNo1AMzMzMzNTjUDNzMzMzHCNQJqZmZmZjY1AZmZmZmaqjUAAAAAAAMiNQM3MzMzM5I1AmpmZmZkBjkAzMzMzMx+OQAAAAAAAPI5AzczMzMxYjkBmZmZmZnaOQDMzMzMzk45AAAAAAACwjkCamZmZmc2OQGZmZmZm6o5AMzMzMzMHj0DNzMzMzCSPQJqZmZmZQY9AMzMzMzNfj0AAAAAAAHyPQM3MzMzMmI9AZmZmZma2j0AzMzMzM9OPQAAAAAAA8I9AzczMzMwGkEAzMzMzMxWQQJqZmZmZI5BAZmZmZmYykEDNzMzMzECQQDMzMzMzT5BAAAAAAABekEBmZmZmZmyQQM3MzMzMepBAmpmZmZmJkEAAAAAAAJiQQM3MzMzMppBAMzMzMzO1kECamZmZmcOQQGZmZmZm0pBAzczMzMzgkEAzMzMzM++QQAAAAAAA/pBAZmZmZmYMkUDNzMzMzBqRQJqZmZmZKZFAAAAAAAA4kUBmZmZmZkaRQDMzMzMzVZFAmpmZmZljkUAAAAAAAHKRQM3MzMzMgJFAMzMzMzOPkUCamZmZmZ2RQGZmZmZmrJFAzczMzMy6kUAzMzMzM8mRQAAAAAAA2JFAZmZmZmbmkUAzMzMzM/WRQJqZmZmZA5JAAAAAAAASkkDNzMzMzCCSQDMzMzMzL5JAmpmZmZk9kkBmZmZmZkySQM3MzMzMWpJAMzMzMzNpkkAAAAAAAHiSQGZmZmZmhpJAzczMzMyUkkCamZmZmaOSQAAAAAAAspJAZmZmZmbAkkAzMzMzM8+SQJqZmZmZ3ZJAAAAAAADskkA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]},\"y\":{\"__ndarray__\":\"x3FNZtr/NEDHcU1m2v80QMdxTWba/zRAGTpC1ep/T0AAAAAAAAAAABk6QtXqf09Ax3FNZtr/NEBN60qB2/9EQBk6QtXqf09A7hQW4TYAVUDuFBbhNgBVQF45fK/mP2JA7hQW4TYAVUBidNl/ToBfQLdawsHtX2JApjizk7jfZEBi17HKiz9aQGJ02X9OgF9ATetKgdv/REAZOkLV6n9PQGLXscqLP1pAx3FNZtr/NEAAAAAAAAAAAMdxTWba/zRATetKgdv/REDHcU1m2v80QAAAAAAAAAAATetKgdv/REAAAAAAAAAAAMdxTWba/zRAAAAAAAAAAADuFBbhNgBVQO4UFuE2AFVAYtexyos/WkDHcU1m2v80QMdxTWba/zRAx3FNZtr/NEAAAAAAAAAAAAAAAAAAAAAAx3FNZtr/NEAAAAAAAAAAAMdxTWba/zRAAAAAAAAAAADHcU1m2v80QMdxTWba/zRAx3FNZtr/NEDHcU1m2v80QE3rSoHb/0RAAAAAAAAAAAAAAAAAAAAAAMdxTWba/zRAAAAAAAAAAAAAAAAAAAAAAMdxTWba/zRAx3FNZtr/NEDHcU1m2v80QAAAAAAAAAAATetKgdv/REAAAAAAAAAAAAAAAAAAAAAAx3FNZtr/NEAAAAAAAAAAAE3rSoHb/0RAx3FNZtr/NEDHcU1m2v80QE3rSoHb/0RAAAAAAAAAAAAZOkLV6n9PQAAAAAAAAAAAx3FNZtr/NEDHcU1m2v80QGJ02X9OgF9AAAAAAAAAAAAZOkLV6n9PQBk6QtXqf09AYtexyos/WkBN60qB2/9EQE3rSoHb/0RAAAAAAAAAAADHcU1m2v80QE3rSoHb/0RATetKgdv/REBidNl/ToBfQBk6QtXqf09Ax3FNZtr/NEC3WsLB7V9iQMHrJ8a2k5BA0jgQuCdWrkDHH1KbK5W3QK35PfrMMrZAWy2hM32JrUDPdc4Aiq+qQHxjZMZ+SKpA59yx9bzzsUCuGpJcDA27QHLHHqFspMNAGDBdwMgPzEAGcnl9GNfOQOBkuqa3X8dAEqrzx0sYu0B/59fvLZ2wQNvKFZMiVqNAMrxCnLJDlkDpMNgUTEiLQB95FxeUZ4dAvWbtKY8/f0CFPoQo5O99QGczvKXE/31ArwgjdFCQd0CvCCN0UJB3QFgjkrWG32xAWCOStYbfbEC3WsLB7V9iQGJ02X9OgF9AYnTZf06AX0AqIjmsLoBvQLdawsHtX2JAGTpC1ep/T0Bi17HKiz9aQGLXscqLP1pAYnTZf06AX0BidNl/ToBfQNZuHTnWv2xAt1rCwe1fYkDvquwzwT9qQO4UFuE2AFVAGTpC1ep/T0DuFBbhNgBVQO4UFuE2AFVATetKgdv/REAAAAAAAAAAALdawsHtX2JAYtexyos/WkDHcU1m2v80QBk6QtXqf09AYnTZf06AX0BN60qB2/9EQE3rSoHb/0RATetKgdv/REBN60qB2/9EQO4UFuE2AFVA7hQW4TYAVUC3WsLB7V9iQE3rSoHb/0RATetKgdv/REAZOkLV6n9PQO4UFuE2AFVAx3FNZtr/NEDuFBbhNgBVQGLXscqLP1pA7hQW4TYAVUDuFBbhNgBVQGJ02X9OgF9AXUjT2AHgdEAAKxZNIVB/QHg4xxjY73RAEQVIEjdYgEAo2FmOtv95QAArFk0hUH9AHbPWJNs/dkBYI5K1ht9sQEJQ8U9hoGdAHbPWJNs/dkDiq4/XN6iKQG5RfUkCUJVAkQPBCh0YlkDxrsHianiHQHg4xxjY73RAKiI5rC6Ab0AqIjmsLoBvQFCIJUQCUHJAt1rCwe1fYkCCrK1g5o9zQGLXscqLP1pAVxU/E2TAVEDJZLD9LIBnQF1I09gB4HRAAVINAyzwcEDvquwzwT9qQGJ02X9OgF9AYnTZf06AX0AZOkLV6n9PQBk6QtXqf09ATetKgdv/REBN60qB2/9EQMdxTWba/zRAYtexyos/WkBidNl/ToBfQNZuHTnWv2xA1m4dOda/bEAZOkLV6n9PQE3rSoHb/0RA7hQW4TYAVUA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]}},\"selected\":{\"id\":\"1174\"},\"selection_policy\":{\"id\":\"1173\"}},\"id\":\"1044\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#1B9E77\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#1B9E77\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#1B9E77\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1095\",\"type\":\"VBar\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1104\"},\"glyph\":{\"id\":\"1112\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1114\"},\"nonselection_glyph\":{\"id\":\"1113\"},\"view\":{\"id\":\"1116\"}},\"id\":\"1115\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"data\":{\"precursor_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_charge\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"x\":{\"__ndarray__\":\"mpmZmZkJgEBmZmZmZiaAQDMzMzMzQ4BAzczMzMxggECamZmZmX2AQGZmZmZmmoBAAAAAAAC4gEDNzMzMzNSAQJqZmZmZ8YBAMzMzMzMPgUAAAAAAACyBQM3MzMzMSIFAZmZmZmZmgUAzMzMzM4OBQAAAAAAAoIFAmpmZmZm9gUBmZmZmZtqBQDMzMzMz94FAzczMzMwUgkCamZmZmTGCQDMzMzMzT4JAAAAAAABsgkDNzMzMzIiCQGZmZmZmpoJAMzMzMzPDgkAAAAAAAOCCQJqZmZmZ/YJAZmZmZmYag0AzMzMzMzeDQM3MzMzMVINAmpmZmZlxg0BmZmZmZo6DQAAAAAAArINAzczMzMzIg0CamZmZmeWDQDMzMzMzA4RAAAAAAAAghEDNzMzMzDyEQGZmZmZmWoRAMzMzMzN3hEAAAAAAAJSEQJqZmZmZsYRAZmZmZmbOhEAAAAAAAOyEQM3MzMzMCIVAmpmZmZklhUAzMzMzM0OFQAAAAAAAYIVAzczMzMx8hUBmZmZmZpqFQDMzMzMzt4VAAAAAAADUhUCamZmZmfGFQGZmZmZmDoZAMzMzMzMrhkDNzMzMzEiGQJqZmZmZZYZAZmZmZmaChkAAAAAAAKCGQM3MzMzMvIZAmpmZmZnZhkAzMzMzM/eGQAAAAAAAFIdAzczMzMwwh0BmZmZmZk6HQDMzMzMza4dAzczMzMyIh0CamZmZmaWHQGZmZmZmwodAAAAAAADgh0DNzMzMzPyHQJqZmZmZGYhAMzMzMzM3iEAAAAAAAFSIQM3MzMzMcIhAZmZmZmaOiEAzMzMzM6uIQAAAAAAAyIhAmpmZmZnliEBmZmZmZgKJQDMzMzMzH4lAzczMzMw8iUCamZmZmVmJQGZmZmZmdolAAAAAAACUiUDNzMzMzLCJQJqZmZmZzYlAMzMzMzPriUAAAAAAAAiKQJqZmZmZJYpAZmZmZmZCikAzMzMzM1+KQM3MzMzMfIpAmpmZmZmZikBmZmZmZraKQAAAAAAA1IpAzczMzMzwikCamZmZmQ2LQDMzMzMzK4tAAAAAAABIi0DNzMzMzGSLQGZmZmZmgotAMzMzMzOfi0AAAAAAALyLQJqZmZmZ2YtAZmZmZmb2i0AzMzMzMxOMQM3MzMzMMIxAmpmZmZlNjEAzMzMzM2uMQAAAAAAAiIxAzczMzMykjEBmZmZmZsKMQDMzMzMz34xAAAAAAAD8jECamZmZmRmNQGZmZmZmNo1AMzMzMzNTjUDNzMzMzHCNQJqZmZmZjY1AZmZmZmaqjUAAAAAAAMiNQM3MzMzM5I1AmpmZmZkBjkAzMzMzMx+OQAAAAAAAPI5AzczMzMxYjkBmZmZmZnaOQDMzMzMzk45AAAAAAACwjkCamZmZmc2OQGZmZmZm6o5AMzMzMzMHj0DNzMzMzCSPQJqZmZmZQY9AMzMzMzNfj0AAAAAAAHyPQM3MzMzMmI9AZmZmZma2j0AzMzMzM9OPQAAAAAAA8I9AzczMzMwGkEAzMzMzMxWQQJqZmZmZI5BAZmZmZmYykEDNzMzMzECQQDMzMzMzT5BAAAAAAABekEBmZmZmZmyQQM3MzMzMepBAmpmZmZmJkEAAAAAAAJiQQM3MzMzMppBAMzMzMzO1kECamZmZmcOQQGZmZmZm0pBAzczMzMzgkEAzMzMzM++QQAAAAAAA/pBAZmZmZmYMkUDNzMzMzBqRQJqZmZmZKZFAAAAAAAA4kUBmZmZmZkaRQDMzMzMzVZFAmpmZmZljkUAAAAAAAHKRQM3MzMzMgJFAMzMzMzOPkUCamZmZmZ2RQGZmZmZmrJFAzczMzMy6kUAzMzMzM8mRQAAAAAAA2JFAZmZmZmbmkUAzMzMzM/WRQJqZmZmZA5JAAAAAAAASkkDNzMzMzCCSQDMzMzMzL5JAmpmZmZk9kkBmZmZmZkySQM3MzMzMWpJAMzMzMzNpkkAAAAAAAHiSQGZmZmZmhpJAzczMzMyUkkCamZmZmaOSQAAAAAAAspJAZmZmZmbAkkAzMzMzM8+SQJqZmZmZ3ZJAAAAAAADskkA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]},\"y\":{\"__ndarray__\":\"ipQm5+D/REAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADCpQcv7/80QMKlBy/v/zRAAAAAAAAAAABuEfI/KIBPQMKlBy/v/zRAipQm5+D/RECsugpn6n9fQAt+lbLs/1lAPMdriktAYkDE8gORGUBaQIqUJufg/0RAwqUHL+//NEBDUdmpSQBVQIqUJufg/0RAbhHyPyiAT0DCpQcv7/80QAAAAAAAAAAAAAAAAAAAAABuEfI/KIBPQMKlBy/v/zRAAAAAAAAAAADCpQcv7/80QIqUJufg/0RAQ1HZqUkAVUDE8gORGUBaQMTyA5EZQFpAAAAAAAAAAADCpQcv7/80QMKlBy/v/zRAipQm5+D/RECKlCbn4P9EQAAAAAAAAAAAxPIDkRlAWkDCpQcv7/80QIqUJufg/0RAwqUHL+//NEAAAAAAAAAAAMKlBy/v/zRAwqUHL+//NEAAAAAAAAAAAMKlBy/v/zRAu16L2/g/X0CKlCbn4P9EQAAAAAAAAAAAAAAAAAAAAACKlCbn4P9EQMKlBy/v/zRAwqUHL+//NEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACKlCbn4P9EQIqUJufg/0RAAAAAAAAAAADCpQcv7/80QMKlBy/v/zRAwqUHL+//NECKlCbn4P9EQG4R8j8ogE9AwqUHL+//NECASAxpv99iQL4Z2wEPIGZAKKlTzTHAY0AC+QkYLYBmQIXRTiRlgGhAZPXcQVNAVkCKlCbn4P9EQENR2alJAFVAQ1HZqUkAVUCKlCbn4P9EQIqUJufg/0RAipQm5+D/REBDUdmpSQBVQA4dmsYwoHNAF5jK9S+Qk0DUQaKhW0yfQBHnbErie5pAfJsGGBIolEB12Cev2FuWQFX36DHM85NAZZy/o1A4nUAYjj47KvCkQHEF/l7XBrBAqdTQVSNbtUAJbFuOyjS5QBP4W6vLxLBAvmvXszKkpkBq8QxUl+eYQAhP4HDEV4lAmTtiTc1fe0AWesCsu69zQHJzc1fSX2dArLoKZ+p/X0CMdiggSJB8QB/aNOgaeJFAKoW8ltKvk0BixBxjMEiCQKSZX3zjX2JAbhHyPyiAT0CkmV98419iQKSZX3zjX2JAxPIDkRlAWkCKlCbn4P9EQAAAAAAAAAAAwqUHL+//NEBuEfI/KIBPQMKlBy/v/zRAwqUHL+//NEDE8gORGUBaQENR2alJAFVAMsOHW8D/ZECsugpn6n9fQENR2alJAFVAipQm5+D/RECKlCbn4P9EQG4R8j8ogE9AQ1HZqUkAVUCKlCbn4P9EQIqUJufg/0RAipQm5+D/REDCpQcv7/80QAAAAAAAAAAAipQm5+D/REDE8gORGUBaQIqUJufg/0RAAAAAAAAAAADCpQcv7/80QMKlBy/v/zRAbhHyPyiAT0A0EwHh2r9UQENR2alJAFVAipQm5+D/REBDUdmpSQBVQDzHa4pLQGJAipQm5+D/REDCpQcv7/80QMKlBy/v/zRAbhHyPyiAT0BuEfI/KIBPQKy6Cmfqf19AOVNchS1gb0DsdlPFEUByQMInSWTf32xAhSTwnYt/b0BM6VnHJABxQG4R8j8ogE9AxPIDkRlAWkCsugpn6n9fQG4R8j8ogE9AMsOHW8D/ZEA5U1yFLWBvQCwRTPIXIHpAJPkMiwlAgkD8z8jHx59nQKyZz/D1D3FAQ1HZqUkAVUBuEfI/KIBPQENR2alJAFVAxPIDkRlAWkD4QVoDqD9qQIqUJufg/0RAQ1HZqUkAVUCKlCbn4P9EQKy6Cmfqf19AmfFnDB+AZ0BDUdmpSQBVQENR2alJAFVAAAAAAAAAAACKlCbn4P9EQENR2alJAFVAipQm5+D/REAAAAAAAAAAAAAAAAAAAAAArLoKZ+p/X0DE8gORGUBaQIqUJufg/0RAipQm5+D/RECkmV98419iQDlTXIUtYG9Ag70YUeDDkEA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]}},\"selected\":{\"id\":\"1178\"},\"selection_policy\":{\"id\":\"1177\"}},\"id\":\"1058\",\"type\":\"ColumnDataSource\"},{\"attributes\":{},\"id\":\"1178\",\"type\":\"Selection\"},{\"attributes\":{\"source\":{\"id\":\"1085\"}},\"id\":\"1097\",\"type\":\"CDSView\"},{\"attributes\":{\"source\":{\"id\":\"1104\"}},\"id\":\"1110\",\"type\":\"CDSView\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#D95F02\"},\"hatch_color\":{\"value\":\"#D95F02\"},\"line_color\":{\"value\":\"#D95F02\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1112\",\"type\":\"VBar\"},{\"attributes\":{\"data\":{\"precursor_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_charge\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"x\":{\"__ndarray__\":\"mpmZmZkJgEBmZmZmZiaAQDMzMzMzQ4BAzczMzMxggECamZmZmX2AQGZmZmZmmoBAAAAAAAC4gEDNzMzMzNSAQJqZmZmZ8YBAMzMzMzMPgUAAAAAAACyBQM3MzMzMSIFAZmZmZmZmgUAzMzMzM4OBQAAAAAAAoIFAmpmZmZm9gUBmZmZmZtqBQDMzMzMz94FAzczMzMwUgkCamZmZmTGCQDMzMzMzT4JAAAAAAABsgkDNzMzMzIiCQGZmZmZmpoJAMzMzMzPDgkAAAAAAAOCCQJqZmZmZ/YJAZmZmZmYag0AzMzMzMzeDQM3MzMzMVINAmpmZmZlxg0BmZmZmZo6DQAAAAAAArINAzczMzMzIg0CamZmZmeWDQDMzMzMzA4RAAAAAAAAghEDNzMzMzDyEQGZmZmZmWoRAMzMzMzN3hEAAAAAAAJSEQJqZmZmZsYRAZmZmZmbOhEAAAAAAAOyEQM3MzMzMCIVAmpmZmZklhUAzMzMzM0OFQAAAAAAAYIVAzczMzMx8hUBmZmZmZpqFQDMzMzMzt4VAAAAAAADUhUCamZmZmfGFQGZmZmZmDoZAMzMzMzMrhkDNzMzMzEiGQJqZmZmZZYZAZmZmZmaChkAAAAAAAKCGQM3MzMzMvIZAmpmZmZnZhkAzMzMzM/eGQAAAAAAAFIdAzczMzMwwh0BmZmZmZk6HQDMzMzMza4dAzczMzMyIh0CamZmZmaWHQGZmZmZmwodAAAAAAADgh0DNzMzMzPyHQJqZmZmZGYhAMzMzMzM3iEAAAAAAAFSIQM3MzMzMcIhAZmZmZmaOiEAzMzMzM6uIQAAAAAAAyIhAmpmZmZnliEBmZmZmZgKJQDMzMzMzH4lAzczMzMw8iUCamZmZmVmJQGZmZmZmdolAAAAAAACUiUDNzMzMzLCJQJqZmZmZzYlAMzMzMzPriUAAAAAAAAiKQJqZmZmZJYpAZmZmZmZCikAzMzMzM1+KQM3MzMzMfIpAmpmZmZmZikBmZmZmZraKQAAAAAAA1IpAzczMzMzwikCamZmZmQ2LQDMzMzMzK4tAAAAAAABIi0DNzMzMzGSLQGZmZmZmgotAMzMzMzOfi0AAAAAAALyLQJqZmZmZ2YtAZmZmZmb2i0AzMzMzMxOMQM3MzMzMMIxAmpmZmZlNjEAzMzMzM2uMQAAAAAAAiIxAzczMzMykjEBmZmZmZsKMQDMzMzMz34xAAAAAAAD8jECamZmZmRmNQGZmZmZmNo1AMzMzMzNTjUDNzMzMzHCNQJqZmZmZjY1AZmZmZmaqjUAAAAAAAMiNQM3MzMzM5I1AmpmZmZkBjkAzMzMzMx+OQAAAAAAAPI5AzczMzMxYjkBmZmZmZnaOQDMzMzMzk45AAAAAAACwjkCamZmZmc2OQGZmZmZm6o5AMzMzMzMHj0DNzMzMzCSPQJqZmZmZQY9AMzMzMzNfj0AAAAAAAHyPQM3MzMzMmI9AZmZmZma2j0AzMzMzM9OPQAAAAAAA8I9AzczMzMwGkEAzMzMzMxWQQJqZmZmZI5BAZmZmZmYykEDNzMzMzECQQDMzMzMzT5BAAAAAAABekEBmZmZmZmyQQM3MzMzMepBAmpmZmZmJkEAAAAAAAJiQQM3MzMzMppBAMzMzMzO1kECamZmZmcOQQGZmZmZm0pBAzczMzMzgkEAzMzMzM++QQAAAAAAA/pBAZmZmZmYMkUDNzMzMzBqRQJqZmZmZKZFAAAAAAAA4kUBmZmZmZkaRQDMzMzMzVZFAmpmZmZljkUAAAAAAAHKRQM3MzMzMgJFAMzMzMzOPkUCamZmZmZ2RQGZmZmZmrJFAzczMzMy6kUAzMzMzM8mRQAAAAAAA2JFAZmZmZmbmkUAzMzMzM/WRQJqZmZmZA5JAAAAAAAASkkDNzMzMzCCSQDMzMzMzL5JAmpmZmZk9kkBmZmZmZkySQM3MzMzMWpJAMzMzMzNpkkAAAAAAAHiSQGZmZmZmhpJAzczMzMyUkkCamZmZmaOSQAAAAAAAspJAZmZmZmbAkkAzMzMzM8+SQJqZmZmZ3ZJAAAAAAADskkA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]},\"y\":{\"__ndarray__\":\"AAAAAAAAAAAAAAAAAAAAAFYy4sZSADVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABWMuLGUgA1QFYy4sZSADVAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABWMuLGUgA1QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFYy4sZSADVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABWMuLGUgA1QAAAAAAAAAAAVjLixlIANUBWMuLGUgA1QAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACOnbIkrP9EQAAAAAAAAAAAjp2yJKz/RECOnbIkrP9EQL2+0qXBX2JA9t24/9iLlEAkG1vu9LuVQC0EDhPZn5VALAJ1Aq7flEA6XnLI3juRQP+tyKL+b4dAMDBQ218wj0BLDWrTqROcQNN1aGHi45tA/+BSBPN7pkCGGps5D3KpQExFhNA9NKJAwKSothZklkDpB745zEeNQLnqW5EeUH9AJQJAZvQ/ckAiYSy35J9nQBN33oK2P2JA/dpn4mZAWkAiYSy35J9nQJFSRyAOAFVAjp2yJKz/RECOnbIkrP9EQJFSRyAOAFVAWFD1CuN/T0COnbIkrP9EQI6dsiSs/0RAjp2yJKz/REBWMuLGUgA1QFYy4sZSADVAAAAAAAAAAABWMuLGUgA1QAAAAAAAAAAAVjLixlIANUBWMuLGUgA1QI6dsiSs/0RAE3fegrY/YkBWMuLGUgA1QFhQ9Qrjf09Ajp2yJKz/REBWMuLGUgA1QFhQ9Qrjf09AAAAAAAAAAABYUPUK439PQI6dsiSs/0RAAAAAAAAAAABWMuLGUgA1QAAAAAAAAAAAAAAAAAAAAABWMuLGUgA1QAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABWMuLGUgA1QAAAAAAAAAAAAAAAAAAAAABWMuLGUgA1QFYy4sZSADVAjp2yJKz/REBWMuLGUgA1QAAAAAAAAAAAAAAAAAAAAACOnbIkrP9EQI6dsiSs/0RAWFD1CuN/T0BYUPUK439PQNBjFxzL/2RAvb7SpcFfYkBYUPUK439PQJFSRyAOAFVAWFD1CuN/T0COnbIkrP9EQFYy4sZSADVAVjLixlIANUDQYxccy/9kQKAfy/T5v2xAvb7SpcFfYkDQYxccy/9kQOBWbcA9gF9ACtJQbEdAX0D92mfiZkBaQAAAAAAAAAAA5bjRCPi/VEBWMuLGUgA1QAAAAAAAAAAAVjLixlIANUCOnbIkrP9EQFhQ9Qrjf09AkVJHIA4AVUBWMuLGUgA1QI6dsiSs/0RAAAAAAAAAAAAAAAAAAAAAAFYy4sZSADVAVjLixlIANUAAAAAAAAAAAFYy4sZSADVAWFD1CuN/T0AAAAAAAAAAAAAAAAAAAAAAVjLixlIANUAAAAAAAAAAAAAAAAAAAAAAVjLixlIANUA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]}},\"selected\":{\"id\":\"1180\"},\"selection_policy\":{\"id\":\"1179\"}},\"id\":\"1065\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1065\"},\"glyph\":{\"id\":\"1067\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1069\"},\"nonselection_glyph\":{\"id\":\"1068\"},\"view\":{\"id\":\"1071\"}},\"id\":\"1070\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#ffbb78\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1061\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"1010\",\"type\":\"LinearScale\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.1},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1119\",\"type\":\"Circle\"},{\"attributes\":{\"data\":{\"precursor_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_charge\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"x\":{\"__ndarray__\":\"mpmZmZkJgEBmZmZmZiaAQDMzMzMzQ4BAzczMzMxggECamZmZmX2AQGZmZmZmmoBAAAAAAAC4gEDNzMzMzNSAQJqZmZmZ8YBAMzMzMzMPgUAAAAAAACyBQM3MzMzMSIFAZmZmZmZmgUAzMzMzM4OBQAAAAAAAoIFAmpmZmZm9gUBmZmZmZtqBQDMzMzMz94FAzczMzMwUgkCamZmZmTGCQDMzMzMzT4JAAAAAAABsgkDNzMzMzIiCQGZmZmZmpoJAMzMzMzPDgkAAAAAAAOCCQJqZmZmZ/YJAZmZmZmYag0AzMzMzMzeDQM3MzMzMVINAmpmZmZlxg0BmZmZmZo6DQAAAAAAArINAzczMzMzIg0CamZmZmeWDQDMzMzMzA4RAAAAAAAAghEDNzMzMzDyEQGZmZmZmWoRAMzMzMzN3hEAAAAAAAJSEQJqZmZmZsYRAZmZmZmbOhEAAAAAAAOyEQM3MzMzMCIVAmpmZmZklhUAzMzMzM0OFQAAAAAAAYIVAzczMzMx8hUBmZmZmZpqFQDMzMzMzt4VAAAAAAADUhUCamZmZmfGFQGZmZmZmDoZAMzMzMzMrhkDNzMzMzEiGQJqZmZmZZYZAZmZmZmaChkAAAAAAAKCGQM3MzMzMvIZAmpmZmZnZhkAzMzMzM/eGQAAAAAAAFIdAzczMzMwwh0BmZmZmZk6HQDMzMzMza4dAzczMzMyIh0CamZmZmaWHQGZmZmZmwodAAAAAAADgh0DNzMzMzPyHQJqZmZmZGYhAMzMzMzM3iEAAAAAAAFSIQM3MzMzMcIhAZmZmZmaOiEAzMzMzM6uIQAAAAAAAyIhAmpmZmZnliEBmZmZmZgKJQDMzMzMzH4lAzczMzMw8iUCamZmZmVmJQGZmZmZmdolAAAAAAACUiUDNzMzMzLCJQJqZmZmZzYlAMzMzMzPriUAAAAAAAAiKQJqZmZmZJYpAZmZmZmZCikAzMzMzM1+KQM3MzMzMfIpAmpmZmZmZikBmZmZmZraKQAAAAAAA1IpAzczMzMzwikCamZmZmQ2LQDMzMzMzK4tAAAAAAABIi0DNzMzMzGSLQGZmZmZmgotAMzMzMzOfi0AAAAAAALyLQJqZmZmZ2YtAZmZmZmb2i0AzMzMzMxOMQM3MzMzMMIxAmpmZmZlNjEAzMzMzM2uMQAAAAAAAiIxAzczMzMykjEBmZmZmZsKMQDMzMzMz34xAAAAAAAD8jECamZmZmRmNQGZmZmZmNo1AMzMzMzNTjUDNzMzMzHCNQJqZmZmZjY1AZmZmZmaqjUAAAAAAAMiNQM3MzMzM5I1AmpmZmZkBjkAzMzMzMx+OQAAAAAAAPI5AzczMzMxYjkBmZmZmZnaOQDMzMzMzk45AAAAAAACwjkCamZmZmc2OQGZmZmZm6o5AMzMzMzMHj0DNzMzMzCSPQJqZmZmZQY9AMzMzMzNfj0AAAAAAAHyPQM3MzMzMmI9AZmZmZma2j0AzMzMzM9OPQAAAAAAA8I9AzczMzMwGkEAzMzMzMxWQQJqZmZmZI5BAZmZmZmYykEDNzMzMzECQQDMzMzMzT5BAAAAAAABekEBmZmZmZmyQQM3MzMzMepBAmpmZmZmJkEAAAAAAAJiQQM3MzMzMppBAMzMzMzO1kECamZmZmcOQQGZmZmZm0pBAzczMzMzgkEAzMzMzM++QQAAAAAAA/pBAZmZmZmYMkUDNzMzMzBqRQJqZmZmZKZFAAAAAAAA4kUBmZmZmZkaRQDMzMzMzVZFAmpmZmZljkUAAAAAAAHKRQM3MzMzMgJFAMzMzMzOPkUCamZmZmZ2RQGZmZmZmrJFAzczMzMy6kUAzMzMzM8mRQAAAAAAA2JFAZmZmZmbmkUAzMzMzM/WRQJqZmZmZA5JAAAAAAAASkkDNzMzMzCCSQDMzMzMzL5JAmpmZmZk9kkBmZmZmZkySQM3MzMzMWpJAMzMzMzNpkkAAAAAAAHiSQGZmZmZmhpJAzczMzMyUkkCamZmZmaOSQAAAAAAAspJAZmZmZmbAkkAzMzMzM8+SQJqZmZmZ3ZJAAAAAAADskkA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]},\"y\":{\"__ndarray__\":\"uWj8sQackEBEq8GNNIiUQKgsz7nY+5NAmPAAqMyHk0C1bPX/8I+XQO9NludNzJZAQ7jj4UAKokBfpyQ589+hQJdV9IvEHaBAWqx9CTwuoEDdz6mtxZujQIebIrM5WqJA7tilHE6AqEChN0goVaysQKpbo42iA6tAHWTMqDf+oUBEBluy38miQGQ7lpo6+qBAAg/ooWQsm0C+6M0TGiCWQCZNOVTd15pA5OViFee3oUCW4zas4++jQLNkxBDM26RALQEU2DZ+o0De1gvBAiSnQIrfTDRMMKpA0qhRAKuhpkBlIzr0S8iWQM/F0Yq565FAnFJr7SZMkEDpfrQirOeZQMOiFaLqR6BArJ1wrx2apUAB6KvY1k+bQLXgsmGLE5pA5j3b6t0rlEB1LBiAJGyYQI3FV5s67JlAu4vmX09okkDOESxcUxiWQODh3OpJBJNAzbYPKkrAlkCwN+KbNViQQGrubWxP8I9An4jxc+ZfkkDaGXe0+nOWQPYKcTMhYJhAERXzs0wUmEBBs+loVlyUQNoZd7T6c5ZAjhPUhQtUmkBGgUDG34OUQG+msIAHRJFALvmJGzbIhkBeFbfo+m+JQB8AG34dQIJAoDRrj1Foh0BtDxvDMOiCQP1MJ7Y87JBAMwfVl/13h0AgGMugRfiNQHbrc9nmN49ALvmJGzbIhkB6mcSRMxCIQGrubWxP8I9AIBjLoEX4jUBBSsAgzveLQGE5JJtkSI9Aj7dViC7EkUDt7M692EuWQP1SPDDl96FAG93+dKK7pUDgaOCgEPqoQGnB6D4yFqdAEKIKCJuXqEBV6LeGna2mQAfLEL9FGKVAKAGXM5UhqkCnuR28y2eiQF/Hw0bu55pAkVLqlvuznUAsSfNIUJiTQJt/HxQN9JtAfthrdBxglUD/Nq2AInyTQL8H5hOOy5xAeoFaCAHkk0B+h5NMQI2yQJ8iw1v+s7FAphlv6BXErkBKSJak36uRQPdvTcQofJtAb4KykhdgmkAJVPwU+yegQNuUeP8yOJxA2eu5+lDglEBDuOPhQAqiQIjw9HDHhL9A4bOKI0OOtEC7+JDX29OnQMXOnXThG6dASkR43DMAoUAb9WHIcCiZQGot9BewF5hAiKmirsyLl0D90xe1SsSWQGrubWxP8I9A1gv5MU3gkkBUeSfVKlCQQIuxwnMOLJhARafuKtm3l0DHMeEa+DeYQL7ozRMaIJZAq7AL+mycmEDqdeGi04uaQOY92+rdK5RA+dxzk13gmkB65rzN8rOZQHWP8CzTQ6dAYR/ce94ho0CwTwm+c8ieQD+B2wAOkJxAzj2e1WzAnEDvkp2GDoySQNoZd7T6c5ZAzwpm1e13lkAHialukGeZQJOoRzvd95RAOr2eLNZ/lkD1vYBmUNyTQEBJ3UNP/J9AZUv21q2zl0AyqfbZtJ+XQAGRpCrvO5lAAuuk4y64mECVn9iVyaebQFsam70QNKNAHhYXdhGMnkBWYmak6bOeQFMOjcwQkKNA1fxYTP23n0Ay8lvO72OmQPyT2lB0EJ5A9Xy7uPc/qkC9mKjvNgCpQAjXkgn+y6ZAft9c/A1QnEBb+tYNaSSYQLlo/LEGnJBAk6hHO933lECg1kgXaoCfQPjUbF0HeqFAPe7RkPd1oEAcBsOH6U+iQBwGw4fpT6JAQ7jj4UAKokDjrVjorPuiQF21+a7NGaNAvU9ghKZ3pkAXMFZ6O0asQKaG1tgbtKdAvIA9SQDQpkA09HcbVByoQBY9joKCv6xA77MSkvPJqEDn6N+t+lekQMiSnTQ1MqRAIQRH3OYhpEAqbQZ+zRuaQOtj/hMiRJBAQ91YfDlYi0Cn1iMD3neKQMCJgSQeWJFAkGx46bVVokCTag0l322gQF9Xcu0EXKFA1R8r6zQwlUCYp/MVNOiTQJx/rOlhwqZAe1ZpXECQpUC8dOFbBaymQJdFqowN9KRAt97jjCSgnEB2TCEzC8ydQN5d/NdqZJhAwr5AbOtVoUBNy0qALSaqQA3y+iPanLNA7xDyEDQbtEDVOd5XW5qrQJn8M+EJDJRA/RP0eFWwmUA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]}},\"selected\":{\"id\":\"1176\"},\"selection_policy\":{\"id\":\"1175\"}},\"id\":\"1051\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"source\":{\"id\":\"1058\"}},\"id\":\"1064\",\"type\":\"CDSView\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.2},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1139\",\"type\":\"Circle\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1051\"},\"glyph\":{\"id\":\"1053\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1055\"},\"nonselection_glyph\":{\"id\":\"1054\"},\"view\":{\"id\":\"1057\"}},\"id\":\"1056\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#E7298A\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#E7298A\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#E7298A\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1145\",\"type\":\"VBar\"},{\"attributes\":{\"callback\":null,\"tooltips\":[[\"index\",\"$index\"],[\"(rt,int)\",\"(@x{0.00}, @y)\"]]},\"id\":\"1027\",\"type\":\"HoverTool\"},{\"attributes\":{\"axis\":{\"id\":\"1012\"},\"coordinates\":null,\"group\":null,\"ticker\":null},\"id\":\"1015\",\"type\":\"Grid\"},{\"attributes\":{\"fill_alpha\":{\"value\":0},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0},\"line_alpha\":{\"value\":0},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1099\",\"type\":\"Circle\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#D95F02\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#D95F02\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#D95F02\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1114\",\"type\":\"VBar\"},{\"attributes\":{\"source\":{\"id\":\"1123\"}},\"id\":\"1141\",\"type\":\"CDSView\"},{\"attributes\":{\"label\":{\"value\":\"y1^1\"},\"renderers\":[{\"id\":\"1049\"}]},\"id\":\"1080\",\"type\":\"LegendItem\"},{\"attributes\":{\"source\":{\"id\":\"1051\"}},\"id\":\"1057\",\"type\":\"CDSView\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.1},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1138\",\"type\":\"Circle\"},{\"attributes\":{\"source\":{\"id\":\"1104\"}},\"id\":\"1116\",\"type\":\"CDSView\"},{\"attributes\":{\"source\":{\"id\":\"1044\"}},\"id\":\"1050\",\"type\":\"CDSView\"},{\"attributes\":{},\"id\":\"1179\",\"type\":\"UnionRenderers\"},{\"attributes\":{},\"id\":\"1006\",\"type\":\"DataRange1d\"},{\"attributes\":{\"fill_alpha\":{\"value\":0},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0},\"line_alpha\":{\"value\":0},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1118\",\"type\":\"Circle\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#7570B3\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#7570B3\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#7570B3\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1132\",\"type\":\"VBar\"},{\"attributes\":{},\"id\":\"1180\",\"type\":\"Selection\"},{\"attributes\":{\"source\":{\"id\":\"1104\"}},\"id\":\"1122\",\"type\":\"CDSView\"},{\"attributes\":{\"data\":{\"Intensity\":[40030.0],\"bottom_int\":[0],\"leftWidth\":[843.921997070312],\"ms2_mscore\":[0.10215831770233398],\"rightWidth\":[916.620971679688]},\"selected\":{\"id\":\"1188\"},\"selection_policy\":{\"id\":\"1187\"}},\"id\":\"1123\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#E7298A\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#E7298A\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#E7298A\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1151\",\"type\":\"VBar\"},{\"attributes\":{},\"id\":\"1008\",\"type\":\"LinearScale\"},{\"attributes\":{\"data\":{\"Intensity\":[40030.0],\"bottom_int\":[0],\"leftWidth\":[843.921997070312],\"ms2_mscore\":[0.4342245125263835],\"rightWidth\":[916.620971679688]},\"selected\":{\"id\":\"1190\"},\"selection_policy\":{\"id\":\"1189\"}},\"id\":\"1142\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1104\"},\"glyph\":{\"id\":\"1118\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1120\"},\"name\":\"leftWidth_apex_point\",\"nonselection_glyph\":{\"id\":\"1119\"},\"view\":{\"id\":\"1122\"}},\"id\":\"1121\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1123\"},\"glyph\":{\"id\":\"1137\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1139\"},\"name\":\"leftWidth_apex_point\",\"nonselection_glyph\":{\"id\":\"1138\"},\"view\":{\"id\":\"1141\"}},\"id\":\"1140\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"label\":{\"value\":\"y3^1\"},\"renderers\":[{\"id\":\"1056\"}]},\"id\":\"1081\",\"type\":\"LegendItem\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.2},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1120\",\"type\":\"Circle\"},{\"attributes\":{},\"id\":\"1024\",\"type\":\"ResetTool\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#aec7e8\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1047\",\"type\":\"Line\"},{\"attributes\":{\"source\":{\"id\":\"1072\"}},\"id\":\"1078\",\"type\":\"CDSView\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#7570B3\"},\"hatch_alpha\":{\"value\":0.1},\"hatch_color\":{\"value\":\"#7570B3\"},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#7570B3\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1126\",\"type\":\"VBar\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#7570B3\"},\"hatch_color\":{\"value\":\"#7570B3\"},\"line_color\":{\"value\":\"#7570B3\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1125\",\"type\":\"VBar\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#E7298A\"},\"hatch_color\":{\"value\":\"#E7298A\"},\"line_color\":{\"value\":\"#E7298A\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1144\",\"type\":\"VBar\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#E7298A\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#E7298A\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#E7298A\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1146\",\"type\":\"VBar\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1142\"},\"glyph\":{\"id\":\"1150\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1152\"},\"nonselection_glyph\":{\"id\":\"1151\"},\"view\":{\"id\":\"1154\"}},\"id\":\"1153\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1142\"},\"glyph\":{\"id\":\"1144\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1146\"},\"nonselection_glyph\":{\"id\":\"1145\"},\"view\":{\"id\":\"1148\"}},\"id\":\"1147\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.1},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1157\",\"type\":\"Circle\"},{\"attributes\":{},\"id\":\"1025\",\"type\":\"HelpTool\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#aec7e8\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1048\",\"type\":\"Line\"},{\"attributes\":{\"source\":{\"id\":\"1142\"}},\"id\":\"1148\",\"type\":\"CDSView\"},{\"attributes\":{},\"id\":\"1181\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#E7298A\"},\"hatch_color\":{\"value\":\"#E7298A\"},\"line_color\":{\"value\":\"#E7298A\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1150\",\"type\":\"VBar\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.1},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.1},\"line_alpha\":{\"value\":0.1},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1100\",\"type\":\"Circle\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1123\"},\"glyph\":{\"id\":\"1125\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1127\"},\"nonselection_glyph\":{\"id\":\"1126\"},\"view\":{\"id\":\"1129\"}},\"id\":\"1128\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"source\":{\"id\":\"1142\"}},\"id\":\"1154\",\"type\":\"CDSView\"},{\"attributes\":{},\"id\":\"1182\",\"type\":\"Selection\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#7570B3\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#7570B3\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#7570B3\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1127\",\"type\":\"VBar\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#E7298A\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#E7298A\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#E7298A\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1152\",\"type\":\"VBar\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.2},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1101\",\"type\":\"Circle\"},{\"attributes\":{\"fill_alpha\":{\"value\":0},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0},\"line_alpha\":{\"value\":0},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1137\",\"type\":\"Circle\"},{\"attributes\":{\"source\":{\"id\":\"1142\"}},\"id\":\"1160\",\"type\":\"CDSView\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1085\"},\"glyph\":{\"id\":\"1099\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1101\"},\"name\":\"leftWidth_apex_point\",\"nonselection_glyph\":{\"id\":\"1100\"},\"view\":{\"id\":\"1103\"}},\"id\":\"1102\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"source\":{\"id\":\"1123\"}},\"id\":\"1129\",\"type\":\"CDSView\"},{\"attributes\":{\"fill_alpha\":{\"value\":0},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0},\"line_alpha\":{\"value\":0},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1156\",\"type\":\"Circle\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#7570B3\"},\"hatch_color\":{\"value\":\"#7570B3\"},\"line_color\":{\"value\":\"#7570B3\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1131\",\"type\":\"VBar\"},{\"attributes\":{},\"id\":\"1189\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"source\":{\"id\":\"1123\"}},\"id\":\"1135\",\"type\":\"CDSView\"},{\"attributes\":{\"overlay\":{\"id\":\"1026\"}},\"id\":\"1022\",\"type\":\"BoxZoomTool\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1142\"},\"glyph\":{\"id\":\"1156\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1158\"},\"name\":\"leftWidth_apex_point\",\"nonselection_glyph\":{\"id\":\"1157\"},\"view\":{\"id\":\"1160\"}},\"id\":\"1159\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#98df8a\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1075\",\"type\":\"Line\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1123\"},\"glyph\":{\"id\":\"1131\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1133\"},\"nonselection_glyph\":{\"id\":\"1132\"},\"view\":{\"id\":\"1135\"}},\"id\":\"1134\",\"type\":\"GlyphRenderer\"},{\"attributes\":{\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#1f77b4\"},\"hatch_alpha\":{\"value\":0.2},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#1f77b4\"},\"x\":{\"field\":\"leftWidth\"},\"y\":{\"field\":\"Intensity\"}},\"id\":\"1158\",\"type\":\"Circle\"},{\"attributes\":{},\"id\":\"1190\",\"type\":\"Selection\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_alpha\":{\"value\":0.2},\"fill_color\":{\"value\":\"#7570B3\"},\"hatch_alpha\":{\"value\":0.2},\"hatch_color\":{\"value\":\"#7570B3\"},\"line_alpha\":{\"value\":0.2},\"line_color\":{\"value\":\"#7570B3\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"rightWidth\"}},\"id\":\"1133\",\"type\":\"VBar\"},{\"attributes\":{},\"id\":\"1183\",\"type\":\"UnionRenderers\"},{\"attributes\":{},\"id\":\"1184\",\"type\":\"Selection\"},{\"attributes\":{},\"id\":\"1167\",\"type\":\"AllLabels\"},{\"attributes\":{\"tools\":[{\"id\":\"1020\"},{\"id\":\"1021\"},{\"id\":\"1022\"},{\"id\":\"1023\"},{\"id\":\"1024\"},{\"id\":\"1025\"},{\"id\":\"1027\"},{\"id\":\"1161\"}]},\"id\":\"1028\",\"type\":\"Toolbar\"},{\"attributes\":{\"coordinates\":null,\"group\":null},\"id\":\"1163\",\"type\":\"Title\"},{\"attributes\":{},\"id\":\"1169\",\"type\":\"BasicTickFormatter\"},{\"attributes\":{\"bottom_units\":\"screen\",\"coordinates\":null,\"fill_alpha\":0.5,\"fill_color\":\"lightgrey\",\"group\":null,\"left_units\":\"screen\",\"level\":\"overlay\",\"line_alpha\":1.0,\"line_color\":\"black\",\"line_dash\":[4,4],\"line_width\":2,\"right_units\":\"screen\",\"syncable\":false,\"top_units\":\"screen\"},\"id\":\"1026\",\"type\":\"BoxAnnotation\"},{\"attributes\":{\"source\":{\"id\":\"1037\"}},\"id\":\"1043\",\"type\":\"CDSView\"},{\"attributes\":{},\"id\":\"1170\",\"type\":\"AllLabels\"},{\"attributes\":{\"line_alpha\":0.5,\"line_color\":\"#ff7f0e\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1053\",\"type\":\"Line\"},{\"attributes\":{\"line_alpha\":0.5,\"line_color\":\"#ffbb78\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1060\",\"type\":\"Line\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#1f77b4\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1040\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"1171\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#1f77b4\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1041\",\"type\":\"Line\"},{\"attributes\":{},\"id\":\"1172\",\"type\":\"Selection\"},{\"attributes\":{\"coordinates\":null,\"data_source\":{\"id\":\"1037\"},\"glyph\":{\"id\":\"1039\"},\"group\":null,\"hover_glyph\":null,\"muted_glyph\":{\"id\":\"1041\"},\"nonselection_glyph\":{\"id\":\"1040\"},\"view\":{\"id\":\"1043\"}},\"id\":\"1042\",\"type\":\"GlyphRenderer\"},{\"attributes\":{},\"id\":\"1185\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"click_policy\":\"mute\",\"coordinates\":null,\"group\":null,\"items\":[{\"id\":\"1079\"},{\"id\":\"1080\"},{\"id\":\"1081\"},{\"id\":\"1082\"},{\"id\":\"1083\"},{\"id\":\"1084\"}],\"label_text_font_size\":\"10pt\",\"location\":\"top_left\",\"title\":\"Transition\"},\"id\":\"1036\",\"type\":\"Legend\"},{\"attributes\":{\"label\":{\"value\":\"b4^1\"},\"renderers\":[{\"id\":\"1077\"}]},\"id\":\"1084\",\"type\":\"LegendItem\"},{\"attributes\":{},\"id\":\"1186\",\"type\":\"Selection\"},{\"attributes\":{\"line_alpha\":0.5,\"line_color\":\"#1f77b4\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1039\",\"type\":\"Line\"},{\"attributes\":{\"data\":{\"precursor_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_charge\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"product_mz\":[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null],\"x\":{\"__ndarray__\":\"mpmZmZkJgEBmZmZmZiaAQDMzMzMzQ4BAzczMzMxggECamZmZmX2AQGZmZmZmmoBAAAAAAAC4gEDNzMzMzNSAQJqZmZmZ8YBAMzMzMzMPgUAAAAAAACyBQM3MzMzMSIFAZmZmZmZmgUAzMzMzM4OBQAAAAAAAoIFAmpmZmZm9gUBmZmZmZtqBQDMzMzMz94FAzczMzMwUgkCamZmZmTGCQDMzMzMzT4JAAAAAAABsgkDNzMzMzIiCQGZmZmZmpoJAMzMzMzPDgkAAAAAAAOCCQJqZmZmZ/YJAZmZmZmYag0AzMzMzMzeDQM3MzMzMVINAmpmZmZlxg0BmZmZmZo6DQAAAAAAArINAzczMzMzIg0CamZmZmeWDQDMzMzMzA4RAAAAAAAAghEDNzMzMzDyEQGZmZmZmWoRAMzMzMzN3hEAAAAAAAJSEQJqZmZmZsYRAZmZmZmbOhEAAAAAAAOyEQM3MzMzMCIVAmpmZmZklhUAzMzMzM0OFQAAAAAAAYIVAzczMzMx8hUBmZmZmZpqFQDMzMzMzt4VAAAAAAADUhUCamZmZmfGFQGZmZmZmDoZAMzMzMzMrhkDNzMzMzEiGQJqZmZmZZYZAZmZmZmaChkAAAAAAAKCGQM3MzMzMvIZAmpmZmZnZhkAzMzMzM/eGQAAAAAAAFIdAzczMzMwwh0BmZmZmZk6HQDMzMzMza4dAzczMzMyIh0CamZmZmaWHQGZmZmZmwodAAAAAAADgh0DNzMzMzPyHQJqZmZmZGYhAMzMzMzM3iEAAAAAAAFSIQM3MzMzMcIhAZmZmZmaOiEAzMzMzM6uIQAAAAAAAyIhAmpmZmZnliEBmZmZmZgKJQDMzMzMzH4lAzczMzMw8iUCamZmZmVmJQGZmZmZmdolAAAAAAACUiUDNzMzMzLCJQJqZmZmZzYlAMzMzMzPriUAAAAAAAAiKQJqZmZmZJYpAZmZmZmZCikAzMzMzM1+KQM3MzMzMfIpAmpmZmZmZikBmZmZmZraKQAAAAAAA1IpAzczMzMzwikCamZmZmQ2LQDMzMzMzK4tAAAAAAABIi0DNzMzMzGSLQGZmZmZmgotAMzMzMzOfi0AAAAAAALyLQJqZmZmZ2YtAZmZmZmb2i0AzMzMzMxOMQM3MzMzMMIxAmpmZmZlNjEAzMzMzM2uMQAAAAAAAiIxAzczMzMykjEBmZmZmZsKMQDMzMzMz34xAAAAAAAD8jECamZmZmRmNQGZmZmZmNo1AMzMzMzNTjUDNzMzMzHCNQJqZmZmZjY1AZmZmZmaqjUAAAAAAAMiNQM3MzMzM5I1AmpmZmZkBjkAzMzMzMx+OQAAAAAAAPI5AzczMzMxYjkBmZmZmZnaOQDMzMzMzk45AAAAAAACwjkCamZmZmc2OQGZmZmZm6o5AMzMzMzMHj0DNzMzMzCSPQJqZmZmZQY9AMzMzMzNfj0AAAAAAAHyPQM3MzMzMmI9AZmZmZma2j0AzMzMzM9OPQAAAAAAA8I9AzczMzMwGkEAzMzMzMxWQQJqZmZmZI5BAZmZmZmYykEDNzMzMzECQQDMzMzMzT5BAAAAAAABekEBmZmZmZmyQQM3MzMzMepBAmpmZmZmJkEAAAAAAAJiQQM3MzMzMppBAMzMzMzO1kECamZmZmcOQQGZmZmZm0pBAzczMzMzgkEAzMzMzM++QQAAAAAAA/pBAZmZmZmYMkUDNzMzMzBqRQJqZmZmZKZFAAAAAAAA4kUBmZmZmZkaRQDMzMzMzVZFAmpmZmZljkUAAAAAAAHKRQM3MzMzMgJFAMzMzMzOPkUCamZmZmZ2RQGZmZmZmrJFAzczMzMy6kUAzMzMzM8mRQAAAAAAA2JFAZmZmZmbmkUAzMzMzM/WRQJqZmZmZA5JAAAAAAAASkkDNzMzMzCCSQDMzMzMzL5JAmpmZmZk9kkBmZmZmZkySQM3MzMzMWpJAMzMzMzNpkkAAAAAAAHiSQGZmZmZmhpJAzczMzMyUkkCamZmZmaOSQAAAAAAAspJAZmZmZmbAkkAzMzMzM8+SQJqZmZmZ3ZJAAAAAAADskkA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]},\"y\":{\"__ndarray__\":\"r8DWuLw/X0AbakyZkH9PQK9w915CQFpAG2pMmZB/T0DZEvuLCwBFQIJZNCUbwFRA/+ZkdkFgYkDmJtXZv/9kQP33PGOxf29Aufj8I9I/akCxxVjwwz9vQK9w915CQFpA/+ZkdkFgYkDmJtXZv/9kQBtqTJmQf09AG2pMmZB/T0AbakyZkH9PQP/mZHZBYGJA5ibV2b//ZEAbakyZkH9PQK9w915CQFpAcHb3UOt/X0D6OUx4z59nQJFKDuWs/1RAG2pMmZB/T0BwdvdQ639fQJFKDuWs/1RAr3D3XkJAWkDZEvuLCwBFQOYm1dm//2RA5ibV2b//ZED/5mR2QWBiQPo5THjPn2dA/+ZkdkFgYkAAAAAAAAAAAHB291Drf19A/+ZkdkFgYkAbakyZkH9PQJFKDuWs/1RAr3D3XkJAWkBh0Alyql9vQPo5THjPn2dA5ibV2b//ZEAbakyZkH9PQPo5THjPn2dA5ibV2b//ZEBh0Alyql9vQGKER11GwGxAr3D3XkJAWkC5+Pwj0j9qQMVNKpUOYHJAETULuiGAhUBcQKBw15eBQP33PGOxf29Aufj8I9I/akD/5mR2QWBiQHB291Drf19Aufj8I9I/akAbakyZkH9PQJFKDuWs/1RAr3D3XkJAWkAbakyZkH9PQHB291Drf19ATV+N4PL/NECRSg7lrP9UQJFKDuWs/1RAXlGINf8/YkC5+Pwj0j9qQLn4/CPSP2pA4R8ljPRPckD99zxjsX9vQK5u0MJ0MHpAxU0qlQ5gckC5+Pwj0j9qQFA/V34foHNAK6ToWfKvfEAbakyZkH9PQOtrl1kBMHZA+FLo8g8AcUBwdvdQ639fQJFKDuWs/1RAcHb3UOt/X0AbakyZkH9PQK9w915CQFpA+jlMeM+fZ0CRSg7lrP9UQOEfJYz0T3JAm7HjdRmQkUAtBBO7LpiUQK4CwKk7vJZAIYjBpcqTkUAEInloZ1iLQChBm6LJT4tAi9qhBzTEk0BSRpUGbqibQD63LMYAWKFAvpVb5nvTrUDN027tG1SxQEexa1o9rqhAL9NQI62ZpkDb8sJi0g+cQHykTlxEQJdAtiOp6yBIjUD6O09euL+IQHEq+HYPwHxAAKqRGRrQeEDFTSqVDmByQH6OhTn+r3NAZVu3HarfbEBh0Alyql9vQP33PGOxf29AcHb3UOt/X0DmJtXZv/9kQPo5THjPn2dAufj8I9I/akDmJtXZv/9kQHB291Drf19A/fc8Y7F/b0DmJtXZv/9kQBEbz2w2EHFASkjX9Q7gZED6OUx4z59nQHoDwoNNkHNAcHb3UOt/X0CRSg7lrP9UQP/mZHZBYGJAG2pMmZB/T0D/5mR2QWBiQNkS+4sLAEVAufj8I9I/akCvcPdeQkBaQNkS+4sLAEVAXlGINf8/YkDhHyWM9E9yQBEbz2w2EHFAw1sf8mBAdkBQP1d+H6BzQOYm1dm//2RAydl88nAAakC5+Pwj0j9qQC9tyUXy/3lAJHsq7hkYjkC5LiHWHGKrQBgyKxXYVL5A1N9h1l7qvUAlj1R0A9e7QFfiQh01nLZAR5Z5OAR7sEAe8mqylY+uQE0Q6POekaxAKd1jPFRupkCHTNxkTFymQC3ye2a6zaJAdF7VmB8ElkDAhcfqgT+PQIX1BlQb+IJAcSr4dg/AfEDFTSqVDmByQCuk6Fnyr3xAw1sf8mBAdkDe4JUR8R96QBaDANvUj4FA6yAczJW/eECoY+Cr3Z+BQGeC7j29J4RA/CmFIEKYg0D/L3p2oB+IQEfeGLyxT39A4R8ljPRPckBlW7cdqt9sQEpI1/UO4GRArEU0dCZwe0ARG89sNhBxQPo5THjPn2dAZVu3HarfbECubtDCdDB6QBEbz2w2EHFAAKqRGRrQeEAYh9+dXwB+QAz5G9yux4RAwJOTd0KQd0DAk5N3QpB3QBiH351fAH5A7WErneovckB6z4kpBpCDQCx0iltoaIlA19T/qmXIiEAdtBv28UeAQPhS6PIPAHFA/VpIvmPweEAtuOfX/J93QNI/KkVXzJhAGWhZSatLqUA=\",\"dtype\":\"float64\",\"order\":\"little\",\"shape\":[193]}},\"selected\":{\"id\":\"1172\"},\"selection_policy\":{\"id\":\"1171\"}},\"id\":\"1037\",\"type\":\"ColumnDataSource\"},{\"attributes\":{\"line_alpha\":0.1,\"line_color\":\"#ff7f0e\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1054\",\"type\":\"Line\"},{\"attributes\":{\"data\":{\"Intensity\":[15781.0],\"bottom_int\":[0],\"leftWidth\":[818.476013183594],\"ms2_mscore\":[0.491091881315617],\"rightWidth\":[847.557983398438]},\"selected\":{\"id\":\"1186\"},\"selection_policy\":{\"id\":\"1185\"}},\"id\":\"1104\",\"type\":\"ColumnDataSource\"},{\"attributes\":{},\"id\":\"1173\",\"type\":\"UnionRenderers\"},{\"attributes\":{\"bottom\":{\"field\":\"bottom_int\"},\"fill_color\":{\"value\":\"#D95F02\"},\"hatch_color\":{\"value\":\"#D95F02\"},\"line_color\":{\"value\":\"#D95F02\"},\"top\":{\"field\":\"Intensity\"},\"width\":{\"value\":0.1},\"x\":{\"field\":\"leftWidth\"}},\"id\":\"1106\",\"type\":\"VBar\"},{\"attributes\":{\"source\":{\"id\":\"1085\"}},\"id\":\"1103\",\"type\":\"CDSView\"},{\"attributes\":{\"line_alpha\":0.2,\"line_color\":\"#ff7f0e\",\"line_width\":2,\"x\":{\"field\":\"x\"},\"y\":{\"field\":\"y\"}},\"id\":\"1055\",\"type\":\"Line\"}],\"root_ids\":[\"1003\"]},\"title\":\"Bokeh Application\",\"version\":\"2.4.3\"}};\n",
+       "  const render_items = [{\"docid\":\"ac525c78-ac23-4720-bdb5-6ac5a440f50d\",\"root_ids\":[\"1003\"],\"roots\":{\"1003\":\"a023eb19-4fe6-4d03-a339-cd4f4a832b28\"}}];\n",
+       "  root.Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
+       "  }\n",
+       "  if (root.Bokeh !== undefined) {\n",
+       "    embed_document(root);\n",
+       "  } else {\n",
+       "    let attempts = 0;\n",
+       "    const timer = setInterval(function(root) {\n",
+       "      if (root.Bokeh !== undefined) {\n",
+       "        clearInterval(timer);\n",
+       "        embed_document(root);\n",
+       "      } else {\n",
+       "        attempts++;\n",
+       "        if (attempts > 100) {\n",
+       "          clearInterval(timer);\n",
+       "          console.log(\"Bokeh: ERROR: Unable to run BokehJS code because BokehJS library is missing\");\n",
+       "        }\n",
+       "      }\n",
+       "    }, 10, root)\n",
+       "  }\n",
+       "})(window);"
+      ],
+      "application/vnd.bokehjs_exec.v0+json": ""
+     },
+     "metadata": {
+      "application/vnd.bokehjs_exec.v0+json": {
+       "id": "1003"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"display: table;\"><div style=\"display: table-row;\"><div style=\"display: table-cell;\"><b title=\"bokeh.plotting.figure.Figure\">Figure</b>(</div><div style=\"display: table-cell;\">id&nbsp;=&nbsp;'1003', <span id=\"1338\" style=\"cursor: pointer;\">&hellip;)</span></div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">above&nbsp;=&nbsp;[],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">align&nbsp;=&nbsp;'start',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">aspect_ratio&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">aspect_scale&nbsp;=&nbsp;1,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">background&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">background_fill_alpha&nbsp;=&nbsp;1.0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">background_fill_color&nbsp;=&nbsp;'#ffffff',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">below&nbsp;=&nbsp;[LinearAxis(id='1012', ...)],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">border_fill_alpha&nbsp;=&nbsp;1.0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">border_fill_color&nbsp;=&nbsp;'#ffffff',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">center&nbsp;=&nbsp;[Grid(id='1015', ...), Grid(id='1019', ...)],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">css_classes&nbsp;=&nbsp;[],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">disabled&nbsp;=&nbsp;False,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">extra_x_ranges&nbsp;=&nbsp;{},</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">extra_x_scales&nbsp;=&nbsp;{},</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">extra_y_ranges&nbsp;=&nbsp;{},</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">extra_y_scales&nbsp;=&nbsp;{},</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">frame_height&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">frame_width&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">height&nbsp;=&nbsp;400,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">height_policy&nbsp;=&nbsp;'auto',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">hidpi&nbsp;=&nbsp;True,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">inner_height&nbsp;=&nbsp;0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">inner_width&nbsp;=&nbsp;0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">js_event_callbacks&nbsp;=&nbsp;{},</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">js_property_callbacks&nbsp;=&nbsp;{},</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">left&nbsp;=&nbsp;[LinearAxis(id='1016', ...)],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">lod_factor&nbsp;=&nbsp;10,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">lod_interval&nbsp;=&nbsp;300,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">lod_threshold&nbsp;=&nbsp;2000,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">lod_timeout&nbsp;=&nbsp;500,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">margin&nbsp;=&nbsp;(0, 0, 0, 0),</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">match_aspect&nbsp;=&nbsp;False,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">max_height&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">max_width&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">min_border&nbsp;=&nbsp;5,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">min_border_bottom&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">min_border_left&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">min_border_right&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">min_border_top&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">min_height&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">min_width&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">name&nbsp;=&nbsp;None,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outer_height&nbsp;=&nbsp;0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outer_width&nbsp;=&nbsp;0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outline_line_alpha&nbsp;=&nbsp;1.0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outline_line_cap&nbsp;=&nbsp;'butt',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outline_line_color&nbsp;=&nbsp;'#e5e5e5',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outline_line_dash&nbsp;=&nbsp;[],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outline_line_dash_offset&nbsp;=&nbsp;0,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outline_line_join&nbsp;=&nbsp;'bevel',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">outline_line_width&nbsp;=&nbsp;1,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">output_backend&nbsp;=&nbsp;'canvas',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">renderers&nbsp;=&nbsp;[GlyphRenderer(id='1042', ...), GlyphRenderer(id='1049', ...), GlyphRenderer(id='1056', ...), GlyphRenderer(id='1063', ...), GlyphRenderer(id='1070', ...), GlyphRenderer(id='1077', ...), GlyphRenderer(id='1090', ...), GlyphRenderer(id='1096', ...), GlyphRenderer(id='1102', ...), GlyphRenderer(id='1109', ...), GlyphRenderer(id='1115', ...), GlyphRenderer(id='1121', ...), GlyphRenderer(id='1128', ...), GlyphRenderer(id='1134', ...), GlyphRenderer(id='1140', ...), GlyphRenderer(id='1147', ...), GlyphRenderer(id='1153', ...), GlyphRenderer(id='1159', ...)],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">reset_policy&nbsp;=&nbsp;'standard',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">right&nbsp;=&nbsp;[Legend(id='1036', ...)],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">sizing_mode&nbsp;=&nbsp;'scale_width',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">subscribed_events&nbsp;=&nbsp;[],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">syncable&nbsp;=&nbsp;True,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">tags&nbsp;=&nbsp;[],</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">title&nbsp;=&nbsp;Title(id='1163', ...),</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">title_location&nbsp;=&nbsp;'above',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">toolbar&nbsp;=&nbsp;Toolbar(id='1028', ...),</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">toolbar_location&nbsp;=&nbsp;'above',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">toolbar_sticky&nbsp;=&nbsp;True,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">visible&nbsp;=&nbsp;True,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">width&nbsp;=&nbsp;800,</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">width_policy&nbsp;=&nbsp;'auto',</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">x_range&nbsp;=&nbsp;DataRange1d(id='1004', ...),</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">x_scale&nbsp;=&nbsp;LinearScale(id='1008', ...),</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">y_range&nbsp;=&nbsp;DataRange1d(id='1006', ...),</div></div><div class=\"1337\" style=\"display: none;\"><div style=\"display: table-cell;\"></div><div style=\"display: table-cell;\">y_scale&nbsp;=&nbsp;LinearScale(id='1010', ...))</div></div></div>\n",
+       "<script>\n",
+       "(function() {\n",
+       "  let expanded = false;\n",
+       "  const ellipsis = document.getElementById(\"1338\");\n",
+       "  ellipsis.addEventListener(\"click\", function() {\n",
+       "    const rows = document.getElementsByClassName(\"1337\");\n",
+       "    for (let i = 0; i < rows.length; i++) {\n",
+       "      const el = rows[i];\n",
+       "      el.style.display = expanded ? \"none\" : \"table-row\";\n",
+       "    }\n",
+       "    ellipsis.innerHTML = expanded ? \"&hellip;)\" : \"&lsaquo;&lsaquo;&lsaquo;\";\n",
+       "    expanded = !expanded;\n",
+       "  });\n",
+       "})();\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "Figure(id='1003', ...)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pep = \"NKESPT(UniMod:21)KAIVR(UniMod:267)\"\n",
+    "charge = 3\n",
+    "\n",
+    "oswLoader.plotChromatogram(\"NKESPT(UniMod:21)KAIVR(UniMod:267)\", charge, smooth=False, includeBoundaries=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "744a8ceb-2b7c-44ce-bd87-3fa90069e456",
+   "metadata": {},
+   "source": [
+    "#### **Visualizing DIA-NN Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa8a3dcd-bb98-4839-a8a8-6cc7b47becb3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a quickstart jupyter notebook to outline how to quickly get started.

I was debating having a separate module called "convenience" however considering the new implementation of SQL I decided it might be easier to have these as methods of the loader objects.

The idea behind this implementation is that if someone just wants quick plotting without learning the ins and outs of the package they can do so. 

Hope to add one of these for DIA-NN chromatograms as well (and maybe .d loader) 