### PR TITLE
[FIX] sqlite programming error when st.caching

### DIFF
--- a/massseer/util.py
+++ b/massseer/util.py
@@ -202,15 +202,13 @@ def check_sqlite_table(con, table):
         bool: True if the table exists, False otherwise.
     """
     table_present = False
-    c = con.cursor()
-    c.execute('SELECT count(name) FROM sqlite_master WHERE type="table" AND name="%s"' % table)
-    if c.fetchone()[0] == 1:
-        table_present = True
-    else:
-        table_present = False
-    c.fetchall()
 
-    return(table_present)
+    result = con.execute('SELECT count(name) FROM sqlite_master WHERE type="table" AND name=?', (table,))
+
+    if result.fetchone()[0] == 1:
+        table_present = True
+
+    return table_present
 
 def check_sqlite_column_in_table(con, table, column):
     """


### PR DESCRIPTION
Use execute direction from conn instead of using cursor.

This addresses #64 

See [ProgrammingError: SQLite objects created in a thread can only be used in that same thread. The object was created in thread id 14408 and this is thread id 2776](https://discuss.streamlit.io/t/programmingerror-sqlite-objects-created-in-a-thread-can-only-be-used-in-that-same-thread-the-object-was-created-in-thread-id-14408-and-this-is-thread-id-2776/17340)