### PR TITLE
Patch/home button

### DIFF
--- a/massdash/constants.py
+++ b/massdash/constants.py
@@ -1,0 +1,28 @@
+"""
+massdash/constants
+~~~~~~~~~~~~
+"""
+
+import os
+from PIL import Image
+
+MASSDASH_DIRNAME = os.path.dirname(__file__)
+
+######################
+## Icons
+MASSDASH_ICON = Image.open(os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo.ico'))
+MASSDASH_LOGO_LIGHT = os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo_Light.png')
+MASSDASH_LOGO_DARK = os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo_Dark.png')
+OPENMS_LOGO = os.path.join(MASSDASH_DIRNAME, 'assets/img/OpenMS.png')
+    
+######################
+## URLS
+
+# Test Data
+# URL_TEST_SQMASS = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/xics/test_chrom_1.sqMass"
+URL_TEST_SQMASS = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/xics/test_1.sqMass"
+# URL_TEST_OSW = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/osw/test_data.osw"
+URL_TEST_OSW = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/osw/test.osw"
+URL_TEST_PQP = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/lib/test.pqp"
+URL_TEST_RAW_MZML = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/raw/test_raw_1.mzML"
+URL_TEST_DREAMDIA_REPORT = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/dreamdia/test_dreamdia_report.tsv"

--- a/massdash/constants.py
+++ b/massdash/constants.py
@@ -19,9 +19,7 @@ OPENMS_LOGO = os.path.join(MASSDASH_DIRNAME, 'assets/img/OpenMS.png')
 ## URLS
 
 # Test Data
-# URL_TEST_SQMASS = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/xics/test_chrom_1.sqMass"
-URL_TEST_SQMASS = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/xics/test_1.sqMass"
-# URL_TEST_OSW = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/osw/test_data.osw"
+URL_TEST_SQMASS = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/xics/test_raw_1.sqMass"
 URL_TEST_OSW = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/osw/test.osw"
 URL_TEST_PQP = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/lib/test.pqp"
 URL_TEST_RAW_MZML = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/raw/test_raw_1.mzML"

--- a/massdash/gui.py
+++ b/massdash/gui.py
@@ -10,6 +10,9 @@ import streamlit as st
 from streamlit_javascript import st_javascript
 from PIL import Image
 
+# Constants
+from massdash.constants import MASSDASH_ICON, MASSDASH_LOGO_LIGHT, MASSDASH_LOGO_DARK, OPENMS_LOGO
+from massdash.constants import URL_TEST_SQMASS, URL_TEST_OSW, URL_TEST_PQP, URL_TEST_RAW_MZML, URL_TEST_DREAMDIA_REPORT
 # Server
 from massdash.server.ExtractedIonChromatogramAnalysisServer import ExtractedIonChromatogramAnalysisServer
 from massdash.server.RawTargetedExtractionAnalysisServer import RawTargetedExtractionAnalysisServer
@@ -17,7 +20,7 @@ from massdash.server.SearchResultsAnalysisServer import SearchResultsAnalysisSer
 # UI 
 from massdash.ui.MassDashGUI import MassDashGUI
 # Utils
-from massdash.util import LOGGER, get_download_folder, download_file
+from massdash.util import LOGGER, get_download_folder, download_file, reset_app, open_page
 
 @click.command()
 # @click.argument('args', default='args', type=str)
@@ -36,17 +39,7 @@ def main(verbose, perf, perf_output):
     LOGGER.setLevel(log_level) 
     
     # Confit
-    MASSDASH_ICON = Image.open(os.path.join(os.path.dirname(__file__), 'assets/img/MassDash_Logo.ico'))
     st.set_page_config(page_title='MassDash', page_icon=MASSDASH_ICON, layout='wide')
-
-    dirname = os.path.dirname(__file__)
-    
-    st_theme = st_javascript("""window.getComputedStyle(window.parent.document.getElementsByClassName("stApp")[0]).getPropertyValue("color-scheme")""")
-    if st_theme == "dark":
-        MASSDASH_LOGO = os.path.join(dirname, 'assets/img/MassDash_Logo_Light.png')
-    else:
-        MASSDASH_LOGO = os.path.join(dirname, 'assets/img/MassDash_Logo_Dark.png')
-    OPENMS_LOGO = os.path.join(dirname, 'assets/img/OpenMS.png')
 
     ###########################
     ## Main Container Window
@@ -61,18 +54,23 @@ def main(verbose, perf, perf_output):
     ## Sidebar Window
 
     # MassDash Sidebar Top Logo
-    st.sidebar.image(MASSDASH_LOGO)
+    st_theme = st_javascript("""window.getComputedStyle(window.parent.document.getElementsByClassName("stApp")[0]).getPropertyValue("color-scheme")""")
+    st.sidebar.image(MASSDASH_LOGO_LIGHT if st_theme == "dark" else MASSDASH_LOGO_DARK)
+    cols = st.sidebar.columns(3)
+    home_button = cols[0].button("🏠 Home", key="home_button", help="Return to the home page.", on_click=reset_app, use_container_width=True)
+    MASSDASH_DOC_URL = "https://massdash.readthedocs.io/en/latest/index.html"
+    documentation_button = cols[1].button("📖 Doc", key="documentation_button", help="Open the MassDash documentation in a new tab.", use_container_width=True, on_click=open_page, args=(MASSDASH_DOC_URL,))
+    MASSDASH_GITHUB_URL = "https://github.com/Roestlab/massdash"
+    github_button = cols[2].button("🐙 GitHub", key="github_button", help="Open the MassDash GitHub repository in a new tab.", use_container_width=True, on_click=open_page, args=(MASSDASH_GITHUB_URL,))
 
     st.sidebar.divider()
 
     if st.session_state.workflow == "xic_data" and st.session_state.clicked['load_toy_dataset_xic_data']:
         tmp_download_folder = get_download_folder() + "/massdash_example_dataset/"
-        sqmass_file_path_input = tmp_download_folder + "/test_chrom_1.sqMass"
-        url_test_sqmass = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/xics/test_chrom_1.sqMass"
-        download_file(url_test_sqmass, tmp_download_folder)
-        osw_file_path = tmp_download_folder + "/test_data.osw"
-        url_test_osw = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/osw/test_data.osw"
-        download_file(url_test_osw, tmp_download_folder)       
+        sqmass_file_path_input = tmp_download_folder + "/test_1.sqMass"
+        download_file(URL_TEST_SQMASS, tmp_download_folder)
+        osw_file_path = tmp_download_folder + "/test.osw"
+        download_file(URL_TEST_OSW, tmp_download_folder)       
         
         massdash_gui.show_file_input_settings(osw_file_path, sqmass_file_path_input)
         
@@ -84,14 +82,11 @@ def main(verbose, perf, perf_output):
     elif st.session_state.workflow == "raw_data" and st.session_state.clicked['load_toy_dataset_raw_data']:
         tmp_download_folder = get_download_folder() + "/massdash_example_dataset/"
         transition_list_file_path = tmp_download_folder + "/test.pqp"
-        url_test_pqp = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/lib/test.pqp"
-        download_file(url_test_pqp, tmp_download_folder)
+        download_file(URL_TEST_PQP, tmp_download_folder)
         raw_file_path_input = tmp_download_folder +  "/test_raw_1.mzML"
-        url_test_raw_mzml = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/raw/test_raw_1.mzML"
-        download_file(url_test_raw_mzml, tmp_download_folder)
+        download_file(URL_TEST_RAW_MZML, tmp_download_folder)
         diann_report_file_path_input = tmp_download_folder + "/test.osw"
-        url_test_osw = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/osw/test.osw"
-        download_file(url_test_osw, tmp_download_folder)
+        download_file(URL_TEST_OSW, tmp_download_folder)
         feature_file_type = "OpenSWATH"
         # st.stop("Toy dataset not available yet.")
         massdash_gui.show_file_input_settings(diann_report_file_path_input, raw_file_path_input, transition_list_file_path, feature_file_type)
@@ -104,13 +99,11 @@ def main(verbose, perf, perf_output):
     if st.session_state.workflow == "search_results_analysis" and st.session_state.clicked['load_toy_dataset_search_results_analysis']:
         tmp_download_folder = get_download_folder() + "/massdash_example_dataset/"
         feature_file_path = tmp_download_folder + "/test.osw"
-        url_test_osw = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/openswath/osw/test.osw"
-        download_file(url_test_osw, tmp_download_folder)
+        download_file(URL_TEST_OSW, tmp_download_folder)
         feature_file_type = "OpenSWATH"
         
         feature_file_path_3 = tmp_download_folder + "/test_dreamdia_report.tsv"
-        url_test_dreamdia_report = "https://github.com/Roestlab/massdash/raw/dev/test/test_data/example_dia/dreamdia/test_dreamdia_report.tsv"
-        download_file(url_test_dreamdia_report, tmp_download_folder)
+        download_file(URL_TEST_DREAMDIA_REPORT, tmp_download_folder)
         feature_file_type_3 = "DreamDIA"
         
         search_results_entries_dict = {'entry_1': {'search_results_file_path':          feature_file_path, 'search_results_exp_name': 'OSW', 'search_results_file_type': feature_file_type}, 

--- a/massdash/gui.py
+++ b/massdash/gui.py
@@ -67,7 +67,7 @@ def main(verbose, perf, perf_output):
 
     if st.session_state.workflow == "xic_data" and st.session_state.clicked['load_toy_dataset_xic_data']:
         tmp_download_folder = get_download_folder() + "/massdash_example_dataset/"
-        sqmass_file_path_input = tmp_download_folder + "/test_1.sqMass"
+        sqmass_file_path_input = tmp_download_folder + "/test_raw_1.sqMass"
         download_file(URL_TEST_SQMASS, tmp_download_folder)
         osw_file_path = tmp_download_folder + "/test.osw"
         download_file(URL_TEST_OSW, tmp_download_folder)       

--- a/massdash/plotting/InteractivePlotter.py
+++ b/massdash/plotting/InteractivePlotter.py
@@ -163,7 +163,7 @@ class InteractivePlotter(GenericPlotter):
             dark2_palette = Viridis256[0:len(features)]
 
         createBoundaryLegend = False
-        st.write('legend_labels', legend_labels)
+        
         if len(legend_labels) > 0:
             if len(legend_labels) != len(features):
                 raise ValueError("The number of legend labels must match the number of features")

--- a/massdash/util.py
+++ b/massdash/util.py
@@ -19,6 +19,8 @@ from logging.handlers import TimedRotatingFileHandler
 import psutil
 
 import requests
+import streamlit as st
+from streamlit.components.v1 import html
 
 
 #######################################
@@ -319,6 +321,29 @@ def download_file(url: str, dest_folder: str):
         LOGGER.info(f"Downloading {url} to {dest_folder}")
         with open(os.path.join(dest_folder, filename), "wb") as f:
             f.write(response.content)
+
+def open_page(url: str):
+    """
+    Opens a new browser window/tab with the specified URL.
+
+    Args:
+        url (str): The URL to open in the new window/tab.
+    """
+    open_script = """
+        <script type="text/javascript">
+            window.open('%s', '_blank').focus();
+        </script>
+    """ % (url)
+    html(open_script)
+    
+def reset_app():
+    """
+    Resets the application by clearing cache data and resources, and resetting session state variables.
+    """
+    st.cache_data.clear()
+    st.cache_resource.clear()
+    st.session_state.WELCOME_PAGE_STATE = True
+    st.session_state.workflow = None
 
 #######################################
 ## Decorators


### PR DESCRIPTION
As discussed with @jcharkow during out OpenSwath dicussion, we thought it would be nice to make the massdash logo clickable to reset the app back to the home landing page without having to click the refresh browser button.

Unfortunately, streamlit doesn't have clickable images in their built in library. However, there are separate streamlit-component libraries (i.e. [st-clickable-images](https://github.com/vivien000/st-clickable-images)) that support this, but this would add an additional dependency.

I wanted to avoid additional streamlit component libraries, so instead I added 3 buttons below the logo: 
1 - home logo to reset to the home landing page, 
2 - docs logo to open a separate the read the docs page, and 
3 - github logo to open a separate github home page.

Note: I unfortunately cannot add the actual github logo in the button, streamlit doesn't allow for custom icons to fill the button.

I also added a constants.py file to move all constant variables into.

![image](https://github.com/Roestlab/massdash/assets/32938975/92e9c7ce-bb19-4641-844f-7591f63e0adb)
