### PR TITLE
fix: remove window_size arg from Conformer call

### DIFF
--- a/massdash/server/ExtractedIonChromatogramAnalysisServer.py
+++ b/massdash/server/ExtractedIonChromatogramAnalysisServer.py
@@ -163,7 +163,7 @@ class ExtractedIonChromatogramAnalysisServer:
                         tr_group.targeted_transition_list = transition_list_ui.target_transition_list
                         print(f"Pretrained model file: {peak_picking_settings.peak_picker_algo_settings.pretrained_model_file}")
                         
-                        peak_picker = ConformerPeakPicker(self.massdash_gui.file_input_settings.osw_file_path, peak_picking_settings.peak_picker_algo_settings.pretrained_model_file, window_size=peak_picking_settings.peak_picker_algo_settings.conformer_window_size, prediction_threshold=peak_picking_settings.peak_picker_algo_settings.conformer_prediction_threshold, prediction_type=peak_picking_settings.peak_picker_algo_settings.conformer_prediction_type)
+                        peak_picker = ConformerPeakPicker(self.massdash_gui.file_input_settings.osw_file_path, peak_picking_settings.peak_picker_algo_settings.pretrained_model_file, prediction_threshold=peak_picking_settings.peak_picker_algo_settings.conformer_prediction_threshold, prediction_type=peak_picking_settings.peak_picker_algo_settings.conformer_prediction_type)
                         # get the trantition in tr_group with the max intensity
                         max_int_transition = np.max([transition.intensity for transition in tr_group.transitionData])
                         peak_features = peak_picker.pick(tr_group, max_int_transition)


### PR DESCRIPTION
# Description

Remove `window_size` arg from conformerPeakPicking call in extracted ion chromatogram server workflow.

Fixes #102 

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested using the GUI with the example test data

# Checklist:

- [ x  ] My code follows the style guidelines of this project
- [  x ] I have performed a self-review of my code
- [  x ] My changes generate no new warnings
- [  x ] New and existing unit tests pass locally with my changes
- [ x  ] Any dependent changes have been merged and published in downstream modules
<!--- START AUTOGENERATED NOTES --->
# Contents ([#103](https://github.com/Roestlab/massdash/pull/103))

### Other
- remove window_size arg from Conformer call

<!--- END AUTOGENERATED NOTES --->