### PR TITLE
Bug/conformer preprocessor

### DIFF
--- a/massdash/structs/Data1D.py
+++ b/massdash/structs/Data1D.py
@@ -132,7 +132,7 @@ class Data1D(ABC):
                 slice_left = slice_right = excess_length // 2
             else: # length % 2 == 1
                 slice_left = excess_length // 2
-                slice_right = excess_length + 1 // 2
+                slice_right = (excess_length + 1) // 2
             new_data = self.data[slice_left:-slice_right]
             new_intensity = self.intensity[slice_left:-slice_right]
         else: # length > len(self.data):

--- a/massdash/structs/Data1D.py
+++ b/massdash/structs/Data1D.py
@@ -122,23 +122,23 @@ class Data1D(ABC):
             (new_data, new_intensity) : tuple of padded/truncated data and intensity
 
         """
-
         #### need to slice the array
         if length == len(self.data):
             new_data = self.data
             new_intensity = self.intensity
         elif length < len(self.data):
-            if length % 2 == 0:
-                slice_left = slice_right = length // 2
+            excess_length = len(self.data) - length
+            if excess_length % 2 == 0:
+                slice_left = slice_right = excess_length // 2
             else: # length % 2 == 1
-                slice_left = length // 2 + 1
-                slice_right = length // 2
+                slice_left = excess_length // 2
+                slice_right = excess_length + 1 // 2
             new_data = self.data[slice_left:-slice_right]
             new_intensity = self.intensity[slice_left:-slice_right]
         else: # length > len(self.data):
             ### infer the chromatogram step size
             step = self.data[1] - self.data[0]
-
+            
             both_even_or_odd = length % 2 == len(self.data) % 2
             if both_even_or_odd:
                 pad_left = pad_right = (length - len(self.data)) // 2

--- a/test/structs/test_Data1D.py
+++ b/test/structs/test_Data1D.py
@@ -1,0 +1,178 @@
+"""
+test/structs/test_Data1D
+~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+
+import unittest
+import numpy as np
+import pandas as pd
+from massdash.structs.Data1D import Data1D
+
+class DummyData1D(Data1D):
+    def toPandasDf(self) -> pd.DataFrame:
+        # Your implementation here (can be a dummy implementation for testing)
+        return pd.DataFrame({'Data': self.data, 'Intensity': self.intensity})
+
+class TestData1D(unittest.TestCase):
+    def test_empty(self):
+        # Test case 1: both data and intensity are empty
+        data = np.array([])
+        intensity = np.array([])
+        obj = DummyData1D(data, intensity)
+        self.assertTrue(obj.empty())
+
+        # Test case 2: data is not empty, intensity is empty
+        data = np.array([1, 2, 3])
+        intensity = np.array([])
+        obj = DummyData1D(data, intensity)
+        self.assertTrue(obj.empty())
+
+        # Test case 3: data is empty, intensity is not empty
+        data = np.array([])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        self.assertTrue(obj.empty())
+
+        # Test case 4: both data and intensity are not empty
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        self.assertFalse(obj.empty())
+
+    def test_max_without_boundary(self):
+        # Test case 1: Maximum intensity without boundary
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        result = obj.max()
+        self.assertEqual(result, (3, 0.9))
+
+        # Test case 2: Maximum intensity without boundary (multiple maximum values)
+        data = np.array([1, 2, 3, 4])
+        intensity = np.array([0.5, 0.8, 0.9, 0.9])
+        obj = DummyData1D(data, intensity)
+        result = obj.max()
+        self.assertEqual(result, (3, 0.9))
+
+    def test_max_with_boundary(self):
+        # Test case 1: Maximum intensity within boundary
+        data = np.array([1, 2, 3, 4, 5])
+        intensity = np.array([0.5, 0.8, 0.9, 0.7, 0.6])
+        obj = DummyData1D(data, intensity)
+        result = obj.max((2, 4))
+        self.assertEqual(result, (3, 0.9))
+
+        # Test case 2: Maximum intensity within boundary (multiple maximum values)
+        data = np.array([1, 2, 3, 4, 5])
+        intensity = np.array([0.5, 0.8, 0.9, 0.9, 0.6])
+        obj = DummyData1D(data, intensity)
+        result = obj.max((2, 4))
+        self.assertEqual(result, (3, 0.9))
+        
+    def test_filter(self):
+        # Test case 1: Filter within boundary
+        data = np.array([1, 2, 3, 4, 5])
+        intensity = np.array([0.5, 0.8, 0.9, 0.7, 0.6])
+        obj = DummyData1D(data, intensity)
+        filtered_obj = obj.filter((2, 4))
+        self.assertTrue(np.array_equal(filtered_obj.data, np.array([2, 3, 4])))
+        self.assertTrue(np.array_equal(filtered_obj.intensity, np.array([0.8, 0.9, 0.7])))
+
+        # Test case 2: Filter with non-tuple boundary
+        data = np.array([1, 2, 3, 4, 5])
+        intensity = np.array([0.5, 0.8, 0.9, 0.7, 0.6])
+        obj = DummyData1D(data, intensity)
+        with self.assertRaises(ValueError):
+            obj.filter(2)
+
+    def test_sum_without_boundary(self):
+        # Test case 1: Sum of all intensities without boundary
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        result = obj.sum()
+        self.assertEqual(result, 2.2)
+
+        # Test case 2: Sum of all intensities without boundary (empty data)
+        data = np.array([])
+        intensity = np.array([])
+        obj = DummyData1D(data, intensity)
+        result = obj.sum()
+        self.assertEqual(result, 0.0)
+
+    def test_sum_with_boundary(self):
+        # Test case 1: Sum of intensities within boundary
+        data = np.array([1, 2, 3, 4, 5])
+        intensity = np.array([0.5, 0.8, 0.9, 0.7, 0.6])
+        obj = DummyData1D(data, intensity)
+        result = obj.sum((2, 4))
+        self.assertAlmostEqual(result, 2.4)
+
+        # Test case 2: Sum of intensities within boundary (empty data)
+        data = np.array([])
+        intensity = np.array([])
+        obj = DummyData1D(data, intensity)
+        result = obj.sum((2, 4))
+        self.assertEqual(result, 0.0)
+        
+    def test_median_without_boundary(self):
+        # Test case 1: Median intensity without boundary
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        result = obj.median()
+        self.assertEqual(result, 0.8)
+
+    def test_median_with_boundary(self):
+        # Test case 1: Median intensity within boundary
+        data = np.array([1, 2, 3, 4, 5])
+        intensity = np.array([0.5, 0.8, 0.9, 0.7, 0.6])
+        obj = DummyData1D(data, intensity)
+        result = obj.median((2, 4))
+        self.assertEqual(result, 0.8)
+
+    def test_adjust_length(self):
+        # Test case 1: length is equal to current length
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        new_data, new_intensity = obj.adjust_length(3)
+        self.assertTrue(np.array_equal(new_data, data))
+        self.assertTrue(np.array_equal(new_intensity, intensity))
+
+        # Test case 2: length is smaller than current length
+        data = np.array([1, 2, 3, 4, 5])
+        intensity = np.array([0.5, 0.8, 0.9, 0.7, 0.6])
+        obj = DummyData1D(data, intensity)
+        new_data, new_intensity = obj.adjust_length(3)
+        self.assertTrue(np.array_equal(new_data, np.array([2, 3, 4])))
+        self.assertTrue(np.array_equal(new_intensity, np.array([0.8, 0.9, 0.7])))
+
+        # Test case 3: length is larger than current length (even length difference)
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        new_data, new_intensity = obj.adjust_length(7)
+        self.assertTrue(np.array_equal(new_data, np.array([-1, 0, 1, 2, 3, 4, 5])))
+        self.assertTrue(np.array_equal(new_intensity, np.array([0, 0, 0.5, 0.8, 0.9, 0, 0])))
+
+        # Test case 4: length is larger than current length (odd length difference)
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        new_data, new_intensity = obj.adjust_length(6)
+        self.assertTrue(np.array_equal(new_data, np.array([-1, 0, 1, 2, 3, 4])))
+        self.assertTrue(np.array_equal(new_intensity, np.array([0, 0, 0.5, 0.8, 0.9, 0])))
+
+        # Test case 5: length is larger than current length (unequal paddings)
+        data = np.array([1, 2, 3])
+        intensity = np.array([0.5, 0.8, 0.9])
+        obj = DummyData1D(data, intensity)
+        new_data, new_intensity = obj.adjust_length(5)
+        self.assertTrue(np.array_equal(new_data, np.array([0, 1, 2, 3, 4])))
+        self.assertTrue(np.array_equal(new_intensity, np.array([0, 0.5, 0.8, 0.9, 0])))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

When performing peak picking with Conformer, depending on the peptide selected, a value error is thrown due to issues with incorrect dimensions. This is due to the `adjust_length` method when `length < len(self.data):`. The current method slices the data 1 point to the left and one point to the right, which results in data with  single dimension data point.

I fixed the method to perform proper data trimming on the left and right. I also added unittests for Data1D.

Fixes #108 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unittests for Data1D class.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<!--- START AUTOGENERATED NOTES --->
# Contents ([#109](https://github.com/Roestlab/massdash/pull/109))

### Other
- [BUG] in adjusting data length when data length is greater than desired length
- [ADD] unittest for Data1D struct
- [LINT] add brackets for bedmas

<!--- END AUTOGENERATED NOTES --->