### PR TITLE
fix: logo image display on windows

### DIFF
--- a/massdash/constants.py
+++ b/massdash/constants.py
@@ -10,11 +10,11 @@ MASSDASH_DIRNAME = os.path.dirname(__file__)
 
 ######################
 ## Icons
-MASSDASH_ICON = Image.open(os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo.ico'))
-MASSDASH_LOGO_LIGHT = os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo_Light.png')
-MASSDASH_LOGO_DARK = os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo_Dark.png')
-OPENMS_LOGO = os.path.join(MASSDASH_DIRNAME, 'assets/img/OpenMS.png')
-    
+MASSDASH_ICON = Image.open(os.path.normpath(os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo.ico')))
+MASSDASH_LOGO_LIGHT = Image.open(os.path.normpath(os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo_Light.png')))
+MASSDASH_LOGO_DARK = Image.open(os.path.normpath(os.path.join(MASSDASH_DIRNAME, 'assets/img/MassDash_Logo_Dark.png')))
+OPENMS_LOGO = Image.open(os.path.normpath(os.path.join(MASSDASH_DIRNAME, 'assets/img/OpenMS.png')))
+
 ######################
 ## URLS
 

--- a/massdash/gui.py
+++ b/massdash/gui.py
@@ -28,7 +28,7 @@ from massdash.util import LOGGER, get_download_folder, download_file, reset_app,
 @click.option('--perf', '-t', is_flag=True, help="Enables measuring and tracking of performance.")
 @click.option('--perf_output', '-o', default='MassDash_Performance_Report.txt', type=str, help="Name of the performance report file to writeout to.")
 def main(verbose, perf, perf_output):     
-    print(MASSDASH_LOGO_DARK)
+    
     ###########################
     ## Logging
     LOGGER.name = 'MassDashGUIMain'

--- a/massdash/gui.py
+++ b/massdash/gui.py
@@ -28,7 +28,7 @@ from massdash.util import LOGGER, get_download_folder, download_file, reset_app,
 @click.option('--perf', '-t', is_flag=True, help="Enables measuring and tracking of performance.")
 @click.option('--perf_output', '-o', default='MassDash_Performance_Report.txt', type=str, help="Name of the performance report file to writeout to.")
 def main(verbose, perf, perf_output):     
-
+    print(MASSDASH_LOGO_DARK)
     ###########################
     ## Logging
     LOGGER.name = 'MassDashGUIMain'


### PR DESCRIPTION
# Description

The logos do not display on windows. This PR fixes this by loading the logo images into a PIL image object, and then displaying the buffered image. Works on windows and linux.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested GUI load and run on windows and linux.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<!--- START AUTOGENERATED NOTES --->
# Contents ([#117](https://github.com/Roestlab/massdash/pull/117))

### Other
- logo image display on windows

### Uncategorised!
- Update gui.py

<!--- END AUTOGENERATED NOTES --->