### PR TITLE
Patch/gui load raw im example bug

### DIFF
--- a/massdash/ui/MassDashGUI.py
+++ b/massdash/ui/MassDashGUI.py
@@ -49,7 +49,7 @@ class MassDashGUI:
         # This is needed because streamlit buttons return True when clicked and then default back to False.
         # See: https://discuss.streamlit.io/t/how-to-make-st-button-content-stick-persist-in-its-own-section/45694/2
         if 'clicked' not in st.session_state:
-            st.session_state.clicked  = {'load_toy_dataset_xic_data':False, 'load_toy_dataset_raw_data':False, 'load_toy_dataset_search_results_analysis':False}
+            st.session_state.clicked  = {'load_toy_dataset_xic_data':False, 'load_toy_dataset_raw_data':False, 'load_toy_dataset_raw_data_im':False,'load_toy_dataset_search_results_analysis':False}
             
         if 'workflow' not in st.session_state:
             st.session_state.workflow = None

--- a/massdash/ui/RawTargetedExtractionAnalysisFormUI.py
+++ b/massdash/ui/RawTargetedExtractionAnalysisFormUI.py
@@ -44,8 +44,9 @@ class RawTargetedExtractionAnalysisFormUI:
 
         st.title("Raw Targeted Data Extraction")
 
-        load_toy_dataset = st.button('Load Raw Targeted Data Extraction Example', on_click=clicked , args=['load_toy_dataset_raw_data'], key='load_toy_dataset_raw_data', help="Loads the raw targeted data extraction example dataset.")
-        load_toy_dataset_im = st.button('Load Raw IM Targeted Data Extraction Example', on_click=clicked , args=['load_toy_dataset_raw_data_im'], key='load_toy_dataset_raw_data_im', help="Loads the raw targeted data with IM extraction example dataset.")
+        col1, col2, col3 = st.columns([0.2, 0.2, 0.6])
+        load_toy_dataset = col1.button('Load Raw Targeted Data Extraction Example', on_click=clicked , args=['load_toy_dataset_raw_data'], key='load_toy_dataset_raw_data', help="Loads the raw targeted data extraction example dataset.")
+        load_toy_dataset_im = col2.button('Load Raw IM Targeted Data Extraction Example', on_click=clicked , args=['load_toy_dataset_raw_data_im'], key='load_toy_dataset_raw_data_im', help="Loads the raw targeted data with IM extraction example dataset.")
         
         if load_toy_dataset:
             st.session_state.workflow = "raw_data"


### PR DESCRIPTION
# Description

When running the raw targeted extraction workflow using the GUI, it fails due to the `load_toy_dataset_raw_data_im` key missing in the streamlit session state variable.

Fixes #121 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested by running the GUI and loading raw files in the raw targeted extraction workflow.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<!--- START AUTOGENERATED NOTES --->
# Contents ([#122](https://github.com/Roestlab/massdash/pull/122))

### Other
- load_toy_dataset_raw_data_im key to streamlit session state
- put load im example button on same row as regular

<!--- END AUTOGENERATED NOTES --->