### PR TITLE
fix: infer names bug, no longer use filename

### DIFF
--- a/massdash/server/ExtractedIonChromatogramAnalysisServer.py
+++ b/massdash/server/ExtractedIonChromatogramAnalysisServer.py
@@ -191,8 +191,7 @@ class ExtractedIonChromatogramAnalysisServer:
                 # Initialize plot object dictionary
                 plot_obj_dict = {}
 
-                filename_mapping = infer_unique_filenames([file.filename for file in tr_group_data.keys()])
-                # st.write(filename_mapping)
+                filename_mapping = infer_unique_filenames([file for file in tr_group_data.keys()])
 
                 # Iterate through each file and generate chromatogram plots
 
@@ -204,7 +203,7 @@ class ExtractedIonChromatogramAnalysisServer:
                     plot_settings_dict = chrom_plot_settings.get_settings()
                     plot_settings_dict['x_axis_label'] = 'Retention Time (s)'
                     plot_settings_dict['y_axis_label'] = 'Intensity'
-                    plot_settings_dict['title'] = filename_mapping[file.filename]
+                    plot_settings_dict['title'] = filename_mapping[file]
                     plot_settings_dict['subtitle'] = f"{transition_list_ui.transition_settings.selected_protein} | {transition_list_ui.transition_settings.selected_peptide}_{transition_list_ui.transition_settings.selected_charge}"
                     
                     if chrom_plot_settings.set_x_range:


### PR DESCRIPTION
# Description

Infer file names used .filename attribute, which is no longer used anymore

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

GUI

**Test Configuration**:
* Firmware version:
* Hardware:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<!--- START AUTOGENERATED NOTES --->
# Contents ([#127](https://github.com/Roestlab/massdash/pull/127))

### Other
- infer names bug, no longer use filename

<!--- END AUTOGENERATED NOTES --->