### PR TITLE
add: button to terminate massdash

### DIFF
--- a/massdash/gui.py
+++ b/massdash/gui.py
@@ -67,8 +67,11 @@ def main(verbose, perf, perf_output, cloud):
     documentation_button = cols[1].button("📖 Doc", key="documentation_button", help="Open the MassDash documentation in a new tab.", use_container_width=True, on_click=open_page, args=(MASSDASH_DOC_URL,))
     MASSDASH_GITHUB_URL = "https://github.com/Roestlab/massdash"
     github_button = cols[2].button("🐙 GitHub", key="github_button", help="Open the MassDash GitHub repository in a new tab.", use_container_width=True, on_click=open_page, args=(MASSDASH_GITHUB_URL,))
-    stop_button = st.sidebar.button("🛑 Exit", key="stop_button", help="Stop the MassDash app.", on_click=close_app, use_container_width=True)
-
+    try:
+        stop_button = st.sidebar.button("🛑 Exit", key="stop_button", help="Stop the MassDash app.", on_click=close_app, use_container_width=True)
+    except Exception:
+        pass
+        
     st.sidebar.divider()
 
     if st.session_state.workflow == "xic_data" and st.session_state.clicked['load_toy_dataset_xic_data']:

--- a/massdash/gui.py
+++ b/massdash/gui.py
@@ -21,7 +21,7 @@ from massdash.server.SearchResultsAnalysisServer import SearchResultsAnalysisSer
 # UI 
 from massdash.ui.MassDashGUI import MassDashGUI
 # Utils
-from massdash.util import LOGGER, get_download_folder, download_file, reset_app, open_page
+from massdash.util import LOGGER, get_download_folder, download_file, reset_app, open_page, close_app
 
 @click.command()
 # @click.argument('args', default='args', type=str)
@@ -48,7 +48,6 @@ def main(verbose, perf, perf_output, cloud):
 
     st.session_state.WELCOME_PAGE_STATE = True
 
-
     # determine if should run in a streamlit cloud context
     isStreamlitCloud = cloud or platform.processor() == "" # will be "" if running on streamlit cloud
 
@@ -68,6 +67,7 @@ def main(verbose, perf, perf_output, cloud):
     documentation_button = cols[1].button("📖 Doc", key="documentation_button", help="Open the MassDash documentation in a new tab.", use_container_width=True, on_click=open_page, args=(MASSDASH_DOC_URL,))
     MASSDASH_GITHUB_URL = "https://github.com/Roestlab/massdash"
     github_button = cols[2].button("🐙 GitHub", key="github_button", help="Open the MassDash GitHub repository in a new tab.", use_container_width=True, on_click=open_page, args=(MASSDASH_GITHUB_URL,))
+    stop_button = st.sidebar.button("🛑 Exit", key="stop_button", help="Stop the MassDash app.", on_click=close_app, use_container_width=True)
 
     st.sidebar.divider()
 

--- a/massdash/util.py
+++ b/massdash/util.py
@@ -429,7 +429,7 @@ def reset_app():
 
 def close_app():
     """
-    Closes 
+    Closes the MassDash app by terminating the Streamlit process and closing the browser tab.
     """
     # Give a bit of delay for user experience
     sleep(5)

--- a/massdash/util.py
+++ b/massdash/util.py
@@ -25,6 +25,8 @@ import requests
 import streamlit as st
 from streamlit.components.v1 import html
 
+from .constants import USER_PLATFORM_SYSTEM
+
 
 #######################################
 ## Logging Utils
@@ -431,16 +433,27 @@ def close_app():
     """
     Closes the MassDash app by terminating the Streamlit process and closing the browser tab.
     """
-    # Give a bit of delay for user experience
-    sleep(5)
-    # Close streamlit browser tab
-    LOGGER.info("Closing MassDash app browser tab...")
-    pyautogui.hotkey('ctrl', 'w')
-    # Terminate streamlit python process
-    pid = os.getpid()
-    LOGGER.info(f"Terminating MassDash app process with PID: {pid}")
-    p = psutil.Process(pid)
-    p.terminate()
+    with st.spinner("Shutting down MassDash..."):
+        # Give a bit of delay for user experience
+        sleep(5)
+        # Close streamlit browser tab
+        LOGGER.info("Closing MassDash app browser tab...")
+        try:
+            if USER_PLATFORM_SYSTEM == "Darwin":
+                pyautogui.hotkey('command', 'w')
+            else:
+                pyautogui.hotkey('ctrl', 'w')
+        except Exception as error:
+            LOGGER.exception(error)
+            LOGGER.info("We tried closing MassDash's browser window, but failed. You will have to close it manually. If you are using MacOS, this is most likely due to a permissions error. You can fix this by doing: System Preferences -> Security & Privacy -> Accessibility -> Terminal 'check'")
+        # Terminate streamlit python process
+        pid = os.getpid()
+        LOGGER.info(f"Terminating MassDash app process with PID: {pid}")
+        try:
+            p = psutil.Process(pid)
+            p.terminate()
+        except Execution as error:
+            LOGGER.exception(error)
 
 #######################################
 ## Decorators

--- a/massdash/util.py
+++ b/massdash/util.py
@@ -13,12 +13,13 @@ from collections import Counter
 # Logging and performance modules
 from functools import wraps
 import contextlib
-from time import time
+from time import time, sleep
 from timeit import default_timer
 from datetime import timedelta
 import logging
 from logging.handlers import TimedRotatingFileHandler
 import psutil
+import pyautogui
 
 import requests
 import streamlit as st
@@ -425,6 +426,21 @@ def reset_app():
     # set everything to unclicked
     for k in st.session_state.clicked.keys():
         st.session_state.clicked[k] = False
+
+def close_app():
+    """
+    Closes 
+    """
+    # Give a bit of delay for user experience
+    sleep(5)
+    # Close streamlit browser tab
+    LOGGER.info("Closing MassDash app browser tab...")
+    pyautogui.hotkey('ctrl', 'w')
+    # Terminate streamlit python process
+    pid = os.getpid()
+    LOGGER.info(f"Terminating MassDash app process with PID: {pid}")
+    p = psutil.Process(pid)
+    p.terminate()
 
 #######################################
 ## Decorators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ requires = [
     "tk",
     "tqdm",
     "upsetplot",
+    "pyautogui",
     "pytest",
     "syrupy"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ streamlit-javascript
 tk
 tqdm
 upsetplot
+pyautogui

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     tk
     tqdm
     upsetplot
+    pyautogui
 
 [bdist_wheel]
 universal = true


### PR DESCRIPTION
# Description

Added exit button to close and terminate massdash process.
This closes the opened massdash tab in the browser, and terminates the PID process of massdash.

This adds an additional dependency: `pyautogui`, for closing the tab.

![image](https://github.com/Roestlab/massdash/assets/32938975/221dd8d8-9911-485b-96e6-00b63db6c3ea)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

GUI

**Test Configuration**:
* Firmware version: popOS
* Hardware: system76

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<!--- START AUTOGENERATED NOTES --->
# Contents ([#128](https://github.com/Roestlab/massdash/pull/128))

### Other
- //github.com/Roestlab/massdash into gui/exit_app
- button to terminate massdash
- docstring info
- pyautogui dependency to project.toml and setup.cfg
- //github.com/Roestlab/massdash into gui/exit_app
- execption handling for shutting massdashdown
- shutting app down on windows

<!--- END AUTOGENERATED NOTES --->