### PR TITLE
fix: disable tkinter file selector for Mac

### DIFF
--- a/massdash/ui/util.py
+++ b/massdash/ui/util.py
@@ -7,6 +7,8 @@ from os import getcwd
 from os.path import dirname
 import streamlit as st
 
+from ..constants import USER_PLATFORM_SYSTEM
+
 def clicked(button):
     """
     Updates the session state to indicate that a button has been clicked.
@@ -94,9 +96,10 @@ def display_input_section(title, key_base: str, file_extension: str, dialog_titl
     with st_cols[0]:
         st.write("\n")
         st.write("\n")
-        dialog_button = st.button("📁", key=f'{key_base}_browse', help=f"Browse for the {title} file.")
-        if dialog_button:
-            st.session_state.tmp_input_dict[key_base] = tk_file_dialog(file_extension, dialog_title, get_parent_directory(st.session_state.tmp_input_dict[key_base]))    
+        if USER_PLATFORM_SYSTEM != "Darwin":
+            dialog_button = st.button("📁", key=f'{key_base}_browse', help=f"Browse for the {title} file.")
+            if dialog_button:
+                st.session_state.tmp_input_dict[key_base] = tk_file_dialog(file_extension, dialog_title, get_parent_directory(st.session_state.tmp_input_dict[key_base]))    
     with st_cols[1]:
         input_value = st.text_input("Enter file path", value=st.session_state.tmp_input_dict[key_base],
                                     placeholder=placeholder, key=f'{key_base}_tmp',


### PR DESCRIPTION
# Description

tkinter file selector currently doesn't work on mac. Disable tkinter file selector if user system is Darwin.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
# How Has This Been Tested?

GUI

**Test Configuration**:
* Firmware version: popOS
* Hardware:system76

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
<!--- START AUTOGENERATED NOTES --->
# Contents ([#132](https://github.com/Roestlab/massdash/pull/132))

### Other
- no tkinter file selector for Mac

<!--- END AUTOGENERATED NOTES --->