### PR TITLE
Patch/sq mass loader low mem

### DIFF
--- a/massdash/loaders/GenericRawDataLoader.py
+++ b/massdash/loaders/GenericRawDataLoader.py
@@ -11,8 +11,6 @@ from pathlib import Path
 from .ResultsLoader import ResultsLoader
 # Structs
 from ..structs import TransitionGroup, TransitionGroupFeature
-from .access import OSWDataAccess
-from .SpectralLibraryLoader import SpectralLibraryLoader
 from ..util import LOGGER, in_notebook
 
 from scipy.signal import savgol_filter, convolve
@@ -35,15 +33,9 @@ class GenericRawDataLoader(ResultsLoader, metaclass=ABCMeta):
         else:
             self.dataFiles = dataFiles
 
-        if self.libraryFile is None:
-            for a in self.rsltsAccess:
-                if isinstance(a, OSWDataAccess): 
-                    self.libraryAccess = SpectralLibraryLoader(a.filename)
-                    self.libraryAccess.load()
-
         ## overwrite run names since we are specifying data files
         self.runNames = [Path(f).stem for f in self.dataFiles]
-        
+
     @abstractmethod
     def loadTransitionGroups(self, pep_id: str, charge: int, runNames: Union[None, str, List[str]]= None) -> Dict[str, TransitionGroup]:
         '''

--- a/massdash/loaders/GenericSpectrumLoader.py
+++ b/massdash/loaders/GenericSpectrumLoader.py
@@ -26,7 +26,7 @@ class GenericSpectrumLoader(GenericRawDataLoader, metaclass=ABCMeta):
         libraryFile: (str) The path to the library file (.tsv or .pqp)
     '''
     
-    def __init__(self, libraryFile, **kwargs):
+    def __init__(self, libraryFile=None, **kwargs):
         super().__init__(**kwargs)
 
         self.libraryFile = libraryFile

--- a/massdash/loaders/MzMLDataLoader.py
+++ b/massdash/loaders/MzMLDataLoader.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 # Loaders
+from .access import MzMLDataAccess
 from .GenericSpectrumLoader import GenericSpectrumLoader
 from .ResultsLoader import ResultsLoader
 # Structs

--- a/massdash/loaders/MzMLDataLoader.py
+++ b/massdash/loaders/MzMLDataLoader.py
@@ -3,14 +3,11 @@ massdash/loaders/MzMLDataLoader
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 
-from os.path import basename, splitext
-from typing import Dict, List, Union, Literal
+from typing import Dict, List, Union
 import numpy as np
 import pandas as pd
 
 # Loaders
-from .access import MzMLDataAccess, OSWDataAccess
-from .SpectralLibraryLoader import SpectralLibraryLoader
 from .GenericSpectrumLoader import GenericSpectrumLoader
 from .ResultsLoader import ResultsLoader
 # Structs
@@ -29,25 +26,11 @@ class MzMLDataLoader(GenericSpectrumLoader):
         libraryFile: (str) The path to the library file (.tsv or .pqp)
         
     '''
-    def __init__(self, libraryFile, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs) 
         self.dataAccess = [MzMLDataAccess(f, 'ondisk', verbose=self.verbose) for f in self.dataFiles]
         self.has_im = np.all([d.has_im for d in self.dataAccess])
-        self.libraryFile = libraryFile
-        self.libraryAccess = None
 
-        # If the library is not explicitly set, 
-        if self.libraryFile is not None:
-            self.libraryAccess = SpectralLibraryLoader(self.libraryFile)
-        else: # self.libraryFile is None:
-            for a in self.rsltsAccess:
-                if isinstance(a, OSWDataAccess): 
-                   self.libraryAccess = SpectralLibraryLoader(a.filename)
-        
-        # If library access is not set, then throw an error
-        if self.libraryAccess is None:
-            raise ValueError("If .osw file is not supplied, library file is required for MzMLDataLoader to perform targeted extraction")
-                   
     @ResultsLoader.cache_results
     def loadTransitionGroups(self, pep_id: str, charge: int, config: TargetedDIAConfig, runNames: Union[None, str, List[str]]=None) -> Dict[str, TransitionGroup]:
         '''

--- a/massdash/loaders/MzMLDataLoader.py
+++ b/massdash/loaders/MzMLDataLoader.py
@@ -9,7 +9,8 @@ import numpy as np
 import pandas as pd
 
 # Loaders
-from .access import MzMLDataAccess
+from .access import MzMLDataAccess, OSWDataAccess
+from .SpectralLibraryLoader import SpectralLibraryLoader
 from .GenericSpectrumLoader import GenericSpectrumLoader
 # Structs
 from ..structs import TransitionGroup, FeatureMap, TargetedDIAConfig, FeatureMapCollection, TopTransitionGroupFeatureCollection, TransitionGroupCollection
@@ -27,10 +28,19 @@ class MzMLDataLoader(GenericSpectrumLoader):
         libraryFile: (str) The path to the library file (.tsv or .pqp)
         
     '''
-    def __init__(self, **kwargs):
+    def __init__(self, libraryFile, **kwargs):
         super().__init__(**kwargs) 
         self.dataAccess = [MzMLDataAccess(f, 'ondisk', verbose=self.verbose) for f in self.dataFiles]
         self.has_im = np.all([d.has_im for d in self.dataAccess])
+        self.libraryFile = libraryFile
+
+        # If the library is not explicitly set, 
+        if self.libraryFile is not None:
+            self.libraryAccess = SpectralLibraryLoader(self.libraryFile)
+        else: # self.libraryFile is None:
+            for a in self.rsltsAccess:
+                if isinstance(a, OSWDataAccess): 
+                   self.libraryAccess = SpectralLibraryLoader(a.filename)
         if self.libraryAccess is None:
             raise ValueError("If .osw file is not supplied, library file is required for MzMLDataLoader to perform targeted extraction")
                    

--- a/massdash/loaders/MzMLDataLoader.py
+++ b/massdash/loaders/MzMLDataLoader.py
@@ -33,6 +33,7 @@ class MzMLDataLoader(GenericSpectrumLoader):
         self.dataAccess = [MzMLDataAccess(f, 'ondisk', verbose=self.verbose) for f in self.dataFiles]
         self.has_im = np.all([d.has_im for d in self.dataAccess])
         self.libraryFile = libraryFile
+        self.libraryAccess = None
 
         # If the library is not explicitly set, 
         if self.libraryFile is not None:
@@ -41,6 +42,8 @@ class MzMLDataLoader(GenericSpectrumLoader):
             for a in self.rsltsAccess:
                 if isinstance(a, OSWDataAccess): 
                    self.libraryAccess = SpectralLibraryLoader(a.filename)
+        
+        # If library access is not set, then throw an error
         if self.libraryAccess is None:
             raise ValueError("If .osw file is not supplied, library file is required for MzMLDataLoader to perform targeted extraction")
                    

--- a/massdash/loaders/MzMLDataLoader.py
+++ b/massdash/loaders/MzMLDataLoader.py
@@ -12,6 +12,7 @@ import pandas as pd
 from .access import MzMLDataAccess, OSWDataAccess
 from .SpectralLibraryLoader import SpectralLibraryLoader
 from .GenericSpectrumLoader import GenericSpectrumLoader
+from .ResultsLoader import ResultsLoader
 # Structs
 from ..structs import TransitionGroup, FeatureMap, TargetedDIAConfig, FeatureMapCollection, TopTransitionGroupFeatureCollection, TransitionGroupCollection
 # Utils
@@ -47,6 +48,7 @@ class MzMLDataLoader(GenericSpectrumLoader):
         if self.libraryAccess is None:
             raise ValueError("If .osw file is not supplied, library file is required for MzMLDataLoader to perform targeted extraction")
                    
+    @ResultsLoader.cache_results
     def loadTransitionGroups(self, pep_id: str, charge: int, config: TargetedDIAConfig, runNames: Union[None, str, List[str]]=None) -> Dict[str, TransitionGroup]:
         '''
         Loads the transition group for a given peptide ID and charge across all files
@@ -63,6 +65,7 @@ class MzMLDataLoader(GenericSpectrumLoader):
 
         return TransitionGroupCollection({ run: data.to_chromatograms() for run, data in out_feature_map.items() })
     
+    @ResultsLoader.cache_results
     def loadTransitionGroupsDf(self, pep_id: str, charge: int, config: TargetedDIAConfig) -> Dict[str, pd.DataFrame]:
         '''
         Loads the transition group for a given peptide ID and charge across all files into a pandas DataFrame
@@ -86,6 +89,7 @@ class MzMLDataLoader(GenericSpectrumLoader):
         out_df = out_df.loc[:,~out_df.columns.duplicated()]
         return out_df
 
+    @ResultsLoader.cache_results
     def loadFeatureMaps(self, pep_id: str, charge: int, config=TargetedDIAConfig, runNames: Union[None, str, List[str]] = None) -> FeatureMapCollection:
         '''
         Loads a dictionary of FeatureMaps (where the keys are the filenames) from the results file

--- a/massdash/loaders/ResultsLoader.py
+++ b/massdash/loaders/ResultsLoader.py
@@ -9,20 +9,19 @@ from typing import Dict, List, Union, Literal, Optional
 import pandas as pd
 from pathlib import Path 
 import numpy as np
+from functools import wraps
 
 # Plotting
 from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource, FactorRange, Whisker, Legend, HoverTool
 from bokeh.palettes import Category10
-from bokeh.layouts import gridplot
 from itertools import cycle
 import plotly.express as px
 
 # Loaders
-from .SpectralLibraryLoader import SpectralLibraryLoader
 from .access import OSWDataAccess, ResultsTSVDataAccess
 # Structs
-from ..structs import TransitionGroup, TransitionGroupFeatureCollection, TopTransitionGroupFeatureCollection
+from ..structs import TransitionGroupFeatureCollection 
 # Utils
 from ..util import LOGGER
 
@@ -51,6 +50,7 @@ class ResultsLoader:
         self.software = None
         self._oswAccess = None
         self._oswAccessChecked = False
+        self.cache = {} # holds the cache of previously loaded peptides so do not have to load again
 
         if isinstance(rsltsFile, str):
             self.rsltsFile = [rsltsFile]
@@ -94,6 +94,24 @@ class ResultsLoader:
         '''
         return [i.getSoftware() for i in self.rsltsAccess]
 
+    def cache_results(func):
+        @wraps(func)
+        def wrapper(self, pep_id, charge, *args, **kwargs):
+            cache_key = (pep_id, charge)
+            result_type = func.__name__
+            if cache_key not in self.cache.keys():
+                print("cache miss")
+                self.cache[cache_key] = {}
+                self.cache[cache_key][result_type] = func(self, pep_id, charge, *args, **kwargs)
+            elif result_type not in self.cache[cache_key].keys():
+                print("cache miss")
+                self.cache[cache_key][result_type] = func(self, pep_id, charge, *args, **kwargs)
+            else:
+                print("cache hit")
+                pass
+            return self.cache[cache_key][result_type]
+        return wrapper 
+
     @abstractmethod
     def loadTransitionGroupFeaturesDf(self, pep_id: str, charge: int) -> pd.DataFrame:
         '''
@@ -108,6 +126,7 @@ class ResultsLoader:
         '''
         pass
 
+    @cache_results
     def loadTransitionGroupFeaturesDf(self, pep_id: str, charge: int, runNames: Union[str, None, List[str]] = None) -> pd.DataFrame:
         '''
         Loads a TransitionGroupFeature object from the results file to a pandas dataframe
@@ -140,6 +159,7 @@ class ResultsLoader:
             
             return pd.concat(out).reset_index(drop=True).drop_duplicates()
 
+    @cache_results
     def loadTransitionGroupFeatures(self, pep_id: str, charge: int, runNames: Union[str, List[str], None] = None) -> TransitionGroupFeatureCollection:
         """
         Load TransitionGroupFeature objects from the results file for the given peptide precursor
@@ -176,6 +196,7 @@ class ResultsLoader:
             raise ValueError("runName must be none, a string or list of strings")
         return out
     
+    @cache_results
     def loadTopTransitionGroupFeatureDf(self, pep_id: str, charge: int) -> pd.DataFrame:
         '''
         Loads a pandas dataframe of TransitionGroupFeatures across all runs 
@@ -193,6 +214,7 @@ class ResultsLoader:
         
         return pd.concat(out).reset_index().drop(columns='level_1').rename(columns=dict(level_0='runName'))
 
+    @cache_results
     def loadTopTransitionGroupFeature(self, pep_id: str, charge: int) -> TransitionGroupFeatureCollection:
         '''
         Loads a PeakFeature object from the results file

--- a/massdash/loaders/ResultsLoader.py
+++ b/massdash/loaders/ResultsLoader.py
@@ -100,14 +100,11 @@ class ResultsLoader:
             cache_key = (pep_id, charge)
             result_type = func.__name__
             if cache_key not in self.cache.keys():
-                print("cache miss")
                 self.cache[cache_key] = {}
                 self.cache[cache_key][result_type] = func(self, pep_id, charge, *args, **kwargs)
             elif result_type not in self.cache[cache_key].keys():
-                print("cache miss")
                 self.cache[cache_key][result_type] = func(self, pep_id, charge, *args, **kwargs)
             else:
-                print("cache hit")
                 pass
             return self.cache[cache_key][result_type]
         return wrapper 

--- a/massdash/loaders/ResultsLoader.py
+++ b/massdash/loaders/ResultsLoader.py
@@ -40,16 +40,14 @@ class ResultsLoader:
 
     def __init__(self, 
                  rsltsFile: Union[str, List[str]], 
-                 libraryFile: str = None,
                  verbose: bool=False, 
                  mode: Literal['module', 'gui'] = 'module'):
 
+        print("in results loader")
         # Attributes (set further down)
         self.rsltsAccess = []
-        self.libraryAccess = None
         self.runNames = None
         self.verbose = verbose
-        self.libraryFile = libraryFile
         self.software = None
         self._oswAccess = None
         self._oswAccessChecked = False
@@ -78,11 +76,6 @@ class ResultsLoader:
         # If called as a Results loader, infer the run names since no raw data will be used.
         self.runNames = self._inferRunNames()
         self.software = self._loadSoftware()
-
-        if self.libraryFile is not None:
-            self.libraryAccess = SpectralLibraryLoader(self.libraryFile)
-            self.libraryAccess.load()
-
 
     def _inferRunNames(self):
         '''

--- a/massdash/loaders/SqMassLoader.py
+++ b/massdash/loaders/SqMassLoader.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 # Loaders
 from .GenericChromatogramLoader import GenericChromatogramLoader
+from .ResultsLoader import ResultsLoader
 from .access import SqMassDataAccess
 # Structs
 from ..structs import TransitionGroup, TransitionGroupCollection
@@ -33,7 +34,7 @@ class SqMassLoader(GenericChromatogramLoader):
         self.oswAccess = self.getOSWAccessPtr()
         if self.oswAccess is None:
             raise ValueError("No OSW file found in SqMassLoader, OSW file required for parsing sqMass files")
-                
+    @ResultsLoader.cache_results
     def loadTransitionGroupsDf(self, pep_id: str, charge: int) -> pd.DataFrame:
         transitionMetaInfo = self.oswAccess.getTransitionIDAnnotationFromSequence(pep_id, charge)
         precursor_id = self.oswAccess.getPrecursorIDFromPeptideAndCharge(pep_id, charge)
@@ -62,6 +63,7 @@ class SqMassLoader(GenericChromatogramLoader):
 
         return pd.concat(out).reset_index().drop('level_1', axis=1).rename(columns=dict(level_0='run'))
 
+    @ResultsLoader.cache_results
     def loadTransitionGroups(self, pep_id: str, charge: int, runNames: Union[None, str, List[str]] =None) -> Dict[str, TransitionGroupCollection]:
         '''
         Loads the transition group for a given peptide ID and charge across all files

--- a/test/loaders/test_ResultsLoader.py
+++ b/test/loaders/test_ResultsLoader.py
@@ -24,18 +24,18 @@ def snapshot_pandas(snapshot):
 @pytest.fixture(params=['openswath', 'diann1', 'combined'])
 def resultsLoader(request):
     if request.param == 'openswath':
-        return ResultsLoader(rsltsFile=f"{TEST_PATH}/test_data/example_dia/openswath/osw/test.osw", libraryFile=None, verbose=False, mode='module')
+        return ResultsLoader(rsltsFile=f"{TEST_PATH}/test_data/example_dia/openswath/osw/test.osw", verbose=False, mode='module')
     elif request.param == 'diann1':
-        return ResultsLoader(rsltsFile=f"{TEST_PATH}/test_data/example_dia/diann/report/test_1_diann_report.tsv", libraryFile=None, verbose=False, mode='module')
+        return ResultsLoader(rsltsFile=f"{TEST_PATH}/test_data/example_dia/diann/report/test_1_diann_report.tsv", verbose=False, mode='module')
     elif request.param == 'combined':
         return ResultsLoader(rsltsFile=[f"{TEST_PATH}/test_data/example_dia/diann/report/test_diann_report_combined.tsv", 
-                                        f"{TEST_PATH}/test_data/example_dia/openswath/osw/test.osw"], libraryFile=None, verbose=False, mode='module')
+                                        f"{TEST_PATH}/test_data/example_dia/openswath/osw/test.osw"], verbose=False, mode='module')
     else:
         raise ValueError(f"Invalid parameter: {request.param}")
 
 @pytest.fixture
 def oswResultsLoader():
-    return ResultsLoader(rsltsFile=f"{TEST_PATH}/test_data/example_dia/openswath/osw/test.osw", libraryFile=None, verbose=False, mode='module')
+    return ResultsLoader(rsltsFile=f"{TEST_PATH}/test_data/example_dia/openswath/osw/test.osw", verbose=False, mode='module')
 
 @pytest.fixture(params=['AGAANIVPNSTGAAK', 'INVALID'])
 def precursor(request):
@@ -110,7 +110,7 @@ def test_computeCV(resultsLoader, snapshot_pandas):
         [[f"{TEST_PATH}/test_data/osw/ionMobilityTest.osw", f"{TEST_PATH}/test_data/example_dia/openswath/osw/test.osw"], None] # multiple osw files
 )  )
 def test_getOSWAccessPtr(rsltsFiles, expected):
-    resultsLoader = ResultsLoader(rsltsFile=rsltsFiles, libraryFile=None, verbose=False, mode='module')
+    resultsLoader = ResultsLoader(rsltsFile=rsltsFiles, verbose=False, mode='module')
     if expected is None:
         assert expected is resultsLoader.getOSWAccessPtr()
     else: # expected is OSWDataAccess


### PR DESCRIPTION
# Description

- Make libraryFiles specific to only GenericSpectrumLoaders (e.g. MzMLLoader) as these are the only files that require a library
- Remove OSW "HashTables" so that initiation of SqMassFiles does not take a long time and is more memory efficient.
- Added a "cache" function to loaders so that peptides already loaded do not have to be reloaded from disk
<!--- START AUTOGENERATED NOTES --->
# Contents ([#154](https://github.com/Roestlab/massdash/pull/154))

### Other
- move library access to MzMLLoader
- fix tests
- cached loaded peptides
- move library checks to GenericSpectrumLoader
- remove print statements
- import statement accidentally deleted
- fix bug that would not allow libraryFile to be None

### Uncategorised!
- Speedup OSWDataAccess initialization

<!--- END AUTOGENERATED NOTES --->