### PR TITLE
check_sqlite_table: also check if entires in table

### DIFF
--- a/massdash/util.py
+++ b/massdash/util.py
@@ -235,7 +235,10 @@ def check_sqlite_table(con, table):
     result = con.execute('SELECT count(name) FROM sqlite_master WHERE type="table" AND name=?', (table,))
 
     if result.fetchone()[0] == 1:
-        table_present = True
+        # ensure the table is not empty
+        result = con.execute(f"SELECT COUNT(*) FROM {table}")
+        if result.fetchone()[0] > 0:
+            table_present = True
 
     return table_present
 


### PR DESCRIPTION
# Description
code that uses the `check_sqlite_table` function assume check is if the table is present and sometimes also that there are entries in the table (table is not empty). To ensure this does not crash in instances where the table is present but is empty, also check that the table is not empty.

Fixes # (issue)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
<!--- START AUTOGENERATED NOTES --->
# Contents ([#155](https://github.com/Roestlab/massdash/pull/155))

### Other
- also check if entires in table

<!--- END AUTOGENERATED NOTES --->