### PR TITLE
Revert "deps: bump bokeh from 2.4.3 to 3.6.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ blinker==1.8.2
     # via streamlit
 blosc2==2.7.1
     # via tables
-bokeh==3.6.2
+bokeh==2.4.3
     # via massdash (pyproject.toml)
 cachetools==5.5.0
     # via streamlit


### PR DESCRIPTION
Reverts Roestlab/massdash#164
<!--- START AUTOGENERATED NOTES --->
# Contents ([#170](https://github.com/Roestlab/massdash/pull/170))

### Other
- bump bokeh from 2.4.3 to 3.6.2"

<!--- END AUTOGENERATED NOTES --->